### PR TITLE
[AIEW-26] CORS 설정과 로그인 흐름 확립

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+### JIRA Task 🔖
+
+- **Ticket**: [AIEW-XX](https://konkuk-graduation-project.atlassian.net/browse/AIEW-XX)
+- **Branch**: feature/AIEW-XX-something
+
+### 작업 내용 📌
+
+(작업한 내용의 핵심을 간결하게 요약합니다.)
+
+-
+-
+-
+
+### 주요 변경 사항 ✍️
+
+(어떤 파일/모듈을 왜, 어떻게 변경했는지 상세하게 기술합니다.)
+
+- **(첫 번째 기능/모듈):**
+  - (세부 변경 사항 1)
+  - (세부 변경 사항 2)
+
+### 테스트 방법 🧑🏻‍🔬
+
+(리뷰어가 이 변경사항을 어떻게 테스트하고 검증할 수 있는지 설명합니다.)
+
+- 예: `pnpm --filter core-api dev` 실행 후, `http://localhost:4000`에서 버튼을 눌러 Google 로그인 테스트
+
+### 참고 사항 📂
+
+(PR을 리뷰하거나 이해하는 데 도움이 될 만한 추가 정보, 링크, 스크린샷 등을 기재합니다.)
+
+-

--- a/apps/core-api/.env.example
+++ b/apps/core-api/.env.example
@@ -1,7 +1,9 @@
+# OAuth 2.0
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-DATABASE_URL="file:./dev.db"
-JWT_SECRET="your-super-secret-key"
-
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# TODO: production 에서는 변경 필요.
+DATABASE_URL="file:./dev.db"
+JWT_SECRET="your-super-secret-key"

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@fastify/autoload": "^6.0.0",
     "@fastify/cookie": "^11.0.2",
+    "@fastify/cors": "^11.0.1",
     "@fastify/jwt": "^9.1.0",
     "@fastify/oauth2": "^8.1.2",
     "@fastify/one-line-logger": "^2.0.2",

--- a/apps/core-api/src/plugins/githubOAuth2.ts
+++ b/apps/core-api/src/plugins/githubOAuth2.ts
@@ -1,3 +1,4 @@
+import { SignPayloadType } from '@fastify/jwt'
 import oauthPlugin, { OAuth2Namespace } from '@fastify/oauth2'
 import axios from 'axios'
 import { FastifyPluginAsync } from 'fastify'
@@ -83,9 +84,25 @@ const githubOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
       }
 
       // 사용자를 위한 JWT 생성
-      const serviceToken = fastify.jwt.sign({ userId: user.id })
+      const payload: SignPayloadType = { userId: user.id }
+      const accessToken: string = await reply.jwtSign(payload, {
+        expiresIn: '15m',
+      })
+      const refreshToken: string = await reply.jwtSign(payload, {
+        expiresIn: '7d',
+      })
 
-      reply.send({ serviceToken })
+      // JWT를 쿠키에 담아 프론트엔드로 리디렉션
+      reply
+        .setCookie('refresh_token', refreshToken, {
+          path: '/',
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정
+          sameSite: 'lax', // CSRF 공격 차단 + 정상적인 요청에서는 GET 허용
+        })
+        .redirect(
+          `http://localhost:4000/auth/callback?accessToken=${accessToken}`,
+        ) // AccessToken은 쿼리로 전달
     } catch (error) {
       fastify.log.error(error)
       reply.status(500).send({ message: 'GitHub login failed' })

--- a/apps/core-api/src/plugins/googleOAuth2.ts
+++ b/apps/core-api/src/plugins/googleOAuth2.ts
@@ -65,12 +65,20 @@ const googleOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
       }
 
       // 사용자를 위한 JWT 생성
-      const serviceToken = fastify.jwt.sign({ userId: user.id })
+      const token = fastify.jwt.sign({ userId: user.id })
 
-      reply.send({ serviceToken })
+      // JWT를 쿠키에 담아 프론트엔드로 리디렉션
+      reply
+        .setCookie('auth_token', token, {
+          path: '/',
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정
+        })
+        .redirect('http://localhost:4000')
     } catch (error) {
       fastify.log.error(error)
-      reply.status(500).send({ message: 'Google login failed' })
+      // 실패 시 에러 메시지와 함께 프론트엔드로 리디렉션할 수도 있음
+      reply.redirect('http://localhost:4000/login-failed')
     }
   })
 }

--- a/apps/core-api/src/plugins/jwt.ts
+++ b/apps/core-api/src/plugins/jwt.ts
@@ -5,6 +5,10 @@ import fp from 'fastify-plugin'
 const jwtPlugin: FastifyPluginAsync = async (fastify) => {
   fastify.register(jwt, {
     secret: process.env.JWT_SECRET as string,
+    cookie: {
+      cookieName: 'refresh_token',
+      signed: false,
+    },
   })
 }
 

--- a/apps/core-api/src/routes/api/me.ts
+++ b/apps/core-api/src/routes/api/me.ts
@@ -1,0 +1,37 @@
+import { FastifyPluginAsync } from 'fastify'
+import fp from 'fastify-plugin'
+
+const meRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    '/api/me',
+    {
+      onRequest: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      // The 'authenticate' hook has already verified the token
+      // and attached the payload to request.user
+      const { userId } = request.user
+
+      const user = await fastify.prisma.user.findUnique({
+        where: { id: userId },
+        // Exclude sensitive data like password if you add it later
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          provider: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      if (!user) {
+        return reply.status(404).send({ message: 'User not found' })
+      }
+
+      return user
+    },
+  )
+}
+
+export default fp(meRoute)

--- a/apps/core-api/src/routes/auth/refresh.ts
+++ b/apps/core-api/src/routes/auth/refresh.ts
@@ -1,0 +1,42 @@
+import { FastifyPluginAsync } from 'fastify'
+import fp from 'fastify-plugin'
+
+interface JWTPayload {
+  userId: string
+}
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/auth/refresh', async (request, reply) => {
+    try {
+      // 1. 쿠키에서 리프레시 토큰을 가져와 검증합니다.
+      //    onlyCookie: true 옵션으로 쿠키만 사용하도록 강제합니다.
+      const userPayload = await request.jwtVerify<JWTPayload>({
+        onlyCookie: true,
+      })
+
+      // 2. DB에서 사용자가 여전히 유효한지 확인합니다.
+      const user = await fastify.prisma.user.findUnique({
+        where: { id: userPayload.userId },
+      })
+
+      if (!user) {
+        reply.clearCookie('refresh_token')
+        return reply.status(401).send({ message: 'Unauthorized' })
+      }
+
+      // 3. 새로운 Access Token을 발급합니다.
+      const accessToken = await reply.jwtSign(
+        { userId: user.id },
+        { expiresIn: '15m' },
+      )
+      return { accessToken }
+    } catch (err) {
+      // 토큰이 유효하지 않거나 만료된 경우
+      fastify.log.error(err)
+      reply.clearCookie('refresh_token')
+      return reply.status(401).send({ message: 'Unauthorized' })
+    }
+  })
+}
+
+export default fp(authRoutes)

--- a/apps/core-api/src/server.ts
+++ b/apps/core-api/src/server.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 
 import AutoLoad from '@fastify/autoload'
 import cookie from '@fastify/cookie'
+import cors from '@fastify/cors'
 import Fastify from 'fastify'
 
 import { app as AppPlugin } from './app'
@@ -20,6 +21,12 @@ const start = async () => {
 
   // Register cookie plugin
   await app.register(cookie)
+
+  // Register CORS plugin
+  await app.register(cors, {
+    origin: 'http://localhost:4000',
+    credentials: true, // Allow cookies to be sent
+  })
 
   // Autoload plugins
   await app.register(AutoLoad, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
+      '@fastify/cors':
+        specifier: ^11.0.1
+        version: 11.0.1
       '@fastify/jwt':
         specifier: ^9.1.0
         version: 9.1.0
@@ -849,6 +852,9 @@ packages:
 
   '@fastify/cookie@11.0.2':
     resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
+
+  '@fastify/cors@11.0.1':
+    resolution: {integrity: sha512-dmZaE7M1f4SM8ZZuk5RhSsDJ+ezTgI7v3HHRj8Ow9CneczsPLZV6+2j2uwdaSLn8zhTv6QV0F4ZRcqdalGx1pQ==}
 
   '@fastify/deepmerge@2.0.2':
     resolution: {integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==}
@@ -3164,16 +3170,16 @@ packages:
       sass:
         optional: true
 
-  nodemon@3.1.10:
-    resolution: {integrity: sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  nodemon@3.1.10:
+    resolution: {integrity: sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4059,7 +4065,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.1
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4111,7 +4117,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -4759,7 +4765,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/types': 7.28.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4960,6 +4966,11 @@ snapshots:
     dependencies:
       cookie: 1.0.2
       fastify-plugin: 5.0.1
+
+  '@fastify/cors@11.0.1':
+    dependencies:
+      fastify-plugin: 5.0.1
+      toad-cache: 3.7.0
 
   '@fastify/deepmerge@2.0.2': {}
 
@@ -6416,8 +6427,8 @@ snapshots:
       '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.4.2))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.29.0(jiti@2.4.2))
@@ -6440,7 +6451,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@5.5.0)
@@ -6451,18 +6462,18 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.9.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -6476,7 +6487,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6487,7 +6498,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7472,6 +7483,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
+  node-releases@2.0.19: {}
+
   nodemon@3.1.10:
     dependencies:
       chokidar: 3.6.0
@@ -7484,13 +7502,6 @@ snapshots:
       supports-color: 5.5.0
       touch: 3.1.1
       undefsafe: 2.0.5
-
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.8.1
-
-  node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
### JIRA Task 🔖
- **Ticket**: [AIEW-26](https://konkuk-graduation-project.atlassian.net/browse/AIEW-26)
- **Branch**: feature/AIEW-26-cors-login-flow

### 작업 내용 📌
1. JWT로 Access/Refresh 토큰 시스템 도입
2. 토큰 재발급 API 구현
3. 보호된 라우트 및 인증 훅(Hook) 구현
4. CORS 설정 확립
5. 개발 워크플로우 개선

### 주요 변경 사항 ✍️
1. JWT로 Access/Refresh 토큰 시스템 도입
    -  토큰 분리: 사용자의 세션 유지를 위해, 수명이 짧은 Access Token (15분)과 수명이 긴 Refresh Token (7일)을 분리하여 발급하도록 구현
    - 안전한 전달:
        - Refresh Token: 탈취 위험을 최소화하기 위해, 자바스크립트가 접근할 수 없는 `HttpOnly` 및 CSRF 방지를 위한 `sameSite: 'lax'` 속성을 부여하여 안전한 쿠키로 전달
        - Access Token: OAuth 콜백 시, 프론트엔드가 즉시 사용할 수 있도록 리디렉션 URL의 쿼리 파라미터로 전달
2. 토큰 재발급 API 구현
    -  `POST /auth/refresh` 엔드포인트를 추가
    - 이 API는 쿠키에 담겨온 유효한 Refresh Token을 검증하여, 만료된 Access Token을 사용자가 재로그인할 필요 없이 조용히 재발급
3. 보호된 라우트 및 인증 훅(Hook) 구현
    -  `fastify.authenticate` 라는 이름의 재사용 가능한 인증 훅(데코레이터) 생성
    - 이 훅은 API 요청의 `Authorization: Bearer <token>` 헤더를 검증하여, 인증된 사용자만 특정 API에 접근하도록 보조
    - `GET /api/me` 엔드포인트를 구현하여, 이 인증 훅을 적용한 보호된 라우트의 실제 예시 구현
4. CORS 설정 확립
    -  `@fastify/cors` 플러그인을 도입하여, 개발 환경에서 프론트엔드(localhost:4000)와 백엔드(localhost:3000)가 원활하게 통신할 수 있도록 설정
    - `credentials: true` 옵션을 통해, 인증 관련 쿠키가 교차 출처 요청에 포함될 수 있도록 허용
5. 개발 워크플로우 개선
    -  일관된 PR 형식 유지를 위해 `.github/PULL_REQUEST_TEMPLATE.md` 파일 추가

### 테스트 방법 🧑🏻‍🔬
1. 프론트에 href=http://localhost:3000/oauth2/google, href=http://localhost:3000/oauth2/github 값을 갖는 a 태그 추가
2. `pnpm dev` 실행
3. 브라우저에서 http://localhost:4000 으로 접근하여 각 a 태그 클릭 후 결과 확인

### 참고 사항 📂
- 지금까지 구현된 api와 향후 만들어질 api에 대한 API Specification은 금주 일요일 내로 작성 예정
- PR 템플릿 적용되지 않는다면 이슈 생성해주세요

[AIEW-26]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ