### PR TITLE
[AIEW-36] Swagger에 등록할 가짜 REST endpoint 생성

### DIFF
--- a/apps/core-api/src/configs/swaggerOption.ts
+++ b/apps/core-api/src/configs/swaggerOption.ts
@@ -43,6 +43,7 @@ enum Tag {
   Interview = '🗣️ 면접',
   Report = '📜 결과 레포트',
   Unclassified = '🏷️ 나중에 태그 OR 삭제 예정',
+  Websocket = '🛰️ WebSocket (테스트 불가)',
 }
 
 export default swaggerOption

--- a/apps/core-api/src/plugins/sharedSchemas.ts
+++ b/apps/core-api/src/plugins/sharedSchemas.ts
@@ -1,13 +1,22 @@
 import { FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 
-import * as schemas from '../schemas/rest'
+import * as restSchemas from '../schemas/rest'
+import * as wsSchemas from '../schemas/ws'
 
 const sharedSchemasPlugin: FastifyPluginAsync = async (
   fastify,
 ): Promise<void> => {
-  for (const schema of Object.values(schemas)) {
+  // REST API 스키마 등록
+  for (const schema of Object.values(restSchemas)) {
     fastify.addSchema(schema)
+  }
+  // WebSocket 스키마 등록
+  for (const schema of Object.values(wsSchemas)) {
+    // 인터페이스나 타입 별칭은 스키마 객체가 아니므로 건너뜁니다.
+    if (typeof schema === 'object' && schema !== null && '$id' in schema) {
+      fastify.addSchema(schema)
+    }
   }
 }
 

--- a/apps/core-api/src/routes/docs/websocket.ts
+++ b/apps/core-api/src/routes/docs/websocket.ts
@@ -1,0 +1,53 @@
+import {
+  FastifyPluginAsync,
+  RouteHandlerMethod,
+  RouteShorthandOptions,
+} from 'fastify'
+import fp from 'fastify-plugin'
+
+import { Tag } from '../../configs/swaggerOption'
+import SchemaId from '../../utils/schemaId'
+
+const websocketDocsRoute: FastifyPluginAsync = async (fastify) => {
+  const path: string = '/docs/websocket-guides/interview'
+  const opts: RouteShorthandOptions = {
+    schema: {
+      tags: [Tag.Websocket],
+      summary: 'AI 면접 WebSocket 통신 가이드',
+      description:
+        '## AI 면접 WebSocket 통신 흐름 가이드\n\n' +
+        '이 문서는 AI 면접 기능의 WebSocket 통신 프로토콜을 설명합니다. **이 엔드포인트를 직접 호출하는 것이 아니라, 아래 명세에 따라 WebSocket 클라이언트를 구현해야 합니다.**\n\n' +
+        '### 통신 순서\n' +
+        '1. 클라이언트는 `POST /interviews` API를 호출하여 면접 세션을 생성하고 `sessionId`를 받습니다.\n' +
+        '2. 클라이언트는 받은 `sessionId`를 사용하여 `ws://localhost:3000/interviews/{sessionId}` 경로로 WebSocket 연결을 수립합니다.\n' +
+        '3. 서버는 AI 질문 생성이 완료되면 `server:questions-ready` 메시지를 클라이언트로 전송합니다.\n' +
+        '4. 클라이언트는 면접을 시작할 준비가 되면 `client:ready` 메시지를 서버로 전송합니다.\n' +
+        '5. (이후 음성 데이터 전송 및 피드백 수신 등의 통신이 이어집니다.)\n',
+      body: {
+        description: '클라이언트가 서버로 보내는 메시지 (C2S)',
+        $ref: SchemaId.WsClientReady,
+      },
+      response: {
+        '200': {
+          description: '서버가 클라이언트로 보내는 메시지 (S2C)',
+          oneOf: [
+            { $ref: SchemaId.WsServerQuestionsReady },
+            { $ref: SchemaId.WsServerError },
+          ],
+        },
+      },
+    },
+  }
+  const handler: RouteHandlerMethod = async (request, reply) => {
+    reply.status(405).send({
+      error: 'Method Not Allowed',
+      message:
+        'This endpoint is for documentation purposes only and should not be called directly.',
+    })
+  }
+
+  // 이 라우트는 문서화 목적으로만 존재하며, 실제 로직은 없습니다.
+  fastify.post(path, opts, handler)
+}
+
+export default fp(websocketDocsRoute)

--- a/apps/core-api/src/schemas/ws/index.ts
+++ b/apps/core-api/src/schemas/ws/index.ts
@@ -1,0 +1,1 @@
+export * from './interview.dto'

--- a/apps/core-api/src/schemas/ws/interview.dto.ts
+++ b/apps/core-api/src/schemas/ws/interview.dto.ts
@@ -1,3 +1,7 @@
+import SchemaId from '../../utils/schemaId'
+
+// --- TypeScript Interfaces for type-safety in code ---
+
 /**
  * 웹소켓을 통해 교환되는 모든 메시지의 기본 구조
  * @template T - payload의 타입
@@ -43,3 +47,62 @@ export interface ClientReadyPayload {
   sessionId: string // 어떤 면접 세션에 대한 준비인지 확인
 }
 export type ClientReadyMessage = WebSocketMessage<ClientReadyPayload>
+
+// --- JSON Schema definitions for documentation ---
+
+export const wsClientReadySchema = {
+  $id: SchemaId.WsClientReady,
+  type: 'object',
+  properties: {
+    type: { type: 'string', const: 'client:ready' },
+    payload: {
+      type: 'object',
+      properties: {
+        sessionId: { type: 'string' },
+      },
+      required: ['sessionId'],
+    },
+  },
+  required: ['type', 'payload'],
+}
+
+export const wsServerQuestionsReadySchema = {
+  $id: SchemaId.WsServerQuestionsReady,
+  type: 'object',
+  properties: {
+    type: { type: 'string', const: 'server:questions-ready' },
+    payload: {
+      type: 'object',
+      properties: {
+        questions: {
+          type: 'object',
+          properties: {
+            technical: { type: 'array', items: { type: 'string' } },
+            personality: { type: 'array', items: { type: 'string' } },
+            tailored: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['technical', 'personality', 'tailored'],
+        },
+      },
+      required: ['questions'],
+    },
+  },
+  required: ['type', 'payload'],
+}
+
+export const wsServerErrorSchema = {
+  $id: SchemaId.WsServerError,
+  type: 'object',
+  properties: {
+    type: { type: 'string', const: 'server:error' },
+    payload: {
+      type: 'object',
+      properties: {
+        code: { type: 'string' },
+        message: { type: 'string' },
+      },
+      required: ['code', 'message'],
+    },
+  },
+  required: ['type', 'payload'],
+}

--- a/apps/core-api/src/schemas/ws/interview.dto.ts
+++ b/apps/core-api/src/schemas/ws/interview.dto.ts
@@ -77,9 +77,36 @@ export const wsServerQuestionsReadySchema = {
         questions: {
           type: 'object',
           properties: {
-            technical: { type: 'array', items: { type: 'string' } },
-            personality: { type: 'array', items: { type: 'string' } },
-            tailored: { type: 'array', items: { type: 'string' } },
+            technical: {
+              type: 'array',
+              items: {
+                type: 'string',
+                const: [
+                  '저희 서비스에서 사용 중인 Fastify의 장단점에 대해 설명해주세요.',
+                  'HTTP와 WebSocket의 차이점을 설명하고, 어떤 상황에서 각각을 사용해야 할까요?',
+                ],
+              },
+            },
+            personality: {
+              type: 'array',
+              items: {
+                type: 'string',
+                const: [
+                  '가장 어려웠던 협업 경험은 무엇이며, 어떻게 해결했나요?',
+                  '스트레스를 관리하는 자신만의 방법이 있나요?',
+                ],
+              },
+            },
+            tailored: {
+              type: 'array',
+              items: {
+                type: 'string',
+                const: [
+                  '제출하신 포트폴리오의 인증 시스템에서 Refresh Token의 역할을 더 자세히 설명해주세요.',
+                  "저희 회사의 인재상인 '끊임없는 학습'을 실천했던 경험이 있다면 말씀해주세요.",
+                ],
+              },
+            },
           },
           required: ['technical', 'personality', 'tailored'],
         },

--- a/apps/core-api/src/utils/schemaId.ts
+++ b/apps/core-api/src/utils/schemaId.ts
@@ -1,6 +1,12 @@
 enum SchemaId {
+  // REST Schemas
   Error = 'ErrorResponse',
   User = 'UserResponse',
+
+  // WebSocket Schemas
+  WsClientReady = 'WsClientReady',
+  WsServerQuestionsReady = 'WsServerQuestionsReady',
+  WsServerError = 'WsServerError',
 }
 
 export default SchemaId


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-36](https://konkuk-graduation-project.atlassian.net/browse/AIEW-36)
- **Branch**: feature/AIEW-36

### 작업 내용 📌

- WebSocket DTO 생성
  - 이에 대한 JSON 스키마 생성
- WebSocket용 가짜 endpoint 생성

### 주요 변경 사항 ✍️

- **WebSocket용 가짜 endpoint 생성**
  - Swagger에서는 일반적으로 RESTful API에 대한 테스트만 가능 (`curl` cli의 한계)
  - 문서화는 단순히 JSON 스키마를 추가하면 되지만 웹소켓 통신에 대한 테스트 방안에 대해 찾아볼 필요가 있음
    - 대안이 없을 경우에는 `pnpm dev`로 매번 full-duplex 연결을 시행해야 함
    - `curl`의 라이브러리나 `ws` 전용 패키지를 사용하면 해결 가능하지만 Swagger에 통합 불가

### 테스트 방법 🧑🏻‍🔬

- `pnpm -F core-api dev` 실행 후, `http://localhost:4000/docs`에서 `🛰️ WebSocket (테스트 불가)` 태그 선택
- 웹소켓 통신과 관련된 내용 확인

### 참고 사항 📂

- https://www.geeksforgeeks.org/python/documenting-websocket-apis-with-swagger/
- https://curl.se/libcurl/c/libcurl-ws.html
- https://github.com/vi/websocat

[AIEW-36]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ