### PR TITLE
[AIEW-31] GET 면접 정보(들)

### DIFF
--- a/apps/core-api/prisma/migrations/20250805082701_add_current_question_index/migration.sql
+++ b/apps/core-api/prisma/migrations/20250805082701_add_current_question_index/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_InterviewSession" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "company" TEXT NOT NULL,
+    "jobTitle" TEXT NOT NULL,
+    "jobSpec" TEXT NOT NULL,
+    "idealTalent" TEXT,
+    "coverLetter" TEXT,
+    "portfolio" TEXT,
+    "questions" JSONB,
+    "currentQuestionIndex" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "InterviewSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_InterviewSession" ("company", "coverLetter", "createdAt", "id", "idealTalent", "jobSpec", "jobTitle", "portfolio", "questions", "updatedAt", "userId") SELECT "company", "coverLetter", "createdAt", "id", "idealTalent", "jobSpec", "jobTitle", "portfolio", "questions", "updatedAt", "userId" FROM "InterviewSession";
+DROP TABLE "InterviewSession";
+ALTER TABLE "new_InterviewSession" RENAME TO "InterviewSession";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -35,6 +35,7 @@ model InterviewSession {
   coverLetter  String? // Path to the stored file
   portfolio    String? // Path to the stored file
   questions    Json?   // AI-generated questions
+  currentQuestionIndex Int      @default(0)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/apps/core-api/src/routes/api/v1/interviews/_sessionId/index.ts
+++ b/apps/core-api/src/routes/api/v1/interviews/_sessionId/index.ts
@@ -1,0 +1,59 @@
+import {
+  FastifyPluginAsync,
+  RequestGenericInterface,
+  RouteHandler,
+  RouteShorthandOptions,
+} from 'fastify'
+
+import { Tag } from '@/configs/swaggerOption'
+import SchemaId from '@/utils/schemaId'
+
+interface requestGeneric extends RequestGenericInterface {
+  Params: {
+    sessionId: string
+  }
+}
+
+const get: FastifyPluginAsync = async (fastify) => {
+  const routePath: string = '/'
+  const opts: RouteShorthandOptions = {
+    onRequest: [fastify.authenticate],
+    schema: {
+      tags: [Tag.Interview],
+      summary: '사용자가 생성한 단일 면접 조회',
+      description: '`sessionId`를 parameter로 받아와 일치하는 면접 조회',
+      params: {
+        type: 'object',
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: '면접 세션의 ID',
+          },
+        },
+        required: ['sessionId'],
+      },
+      response: {
+        200: {
+          $ref: SchemaId.Interview,
+        },
+        404: {
+          $ref: SchemaId.Error,
+        },
+      },
+    },
+  }
+  const handler: RouteHandler<requestGeneric> = async (request, reply) => {
+    const session = await fastify.prisma.interviewSession.findFirst({
+      where: {
+        id: request.params.sessionId,
+        userId: request.user.userId,
+      },
+    })
+
+    if (!session) return reply.notFound('')
+    reply.send(session)
+  }
+  fastify.get<requestGeneric>(routePath, opts, handler)
+}
+
+export default get

--- a/apps/core-api/src/routes/api/v1/interviews/create/index.ts
+++ b/apps/core-api/src/routes/api/v1/interviews/create/index.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pipeline } from 'node:stream'
+import { promisify } from 'node:util'
+
+import {
+  FastifyPluginAsync,
+  RouteHandlerMethod,
+  RouteShorthandOptions,
+} from 'fastify'
+
+import { Tag } from '@/configs/swaggerOption'
+import SchemaId from '@/utils/schemaId'
+
+const pump = promisify(pipeline)
+
+// request.body에 추가될 필드들의 타입을 정의합니다.
+interface InterviewRequestBody {
+  company: { value: string }
+  jobTitle: { value: string }
+  jobSpec: { value: string }
+  idealTalent: { value: string }
+}
+
+const interviewsRoute: FastifyPluginAsync = async (fastify) => {
+  const routePath = '/'
+
+  const postOpts: RouteShorthandOptions = {
+    onRequest: [fastify.authenticate],
+    schema: {
+      tags: [Tag.Interview],
+      summary: '새로운 AI 면접 세션 생성',
+      description:
+        '사용자로부터 회사, 직무, 자기소개서, 포트폴리오, 인재상 등의 정보를 받아 새로운 면접 세션을 생성하고,<br>\
+        백그라운드에서 AI 질문 생성을 시작합니다.<br>\
+        자기소개서와 포트폴리오는 PDF 파일만 업로드 가능합니다.<br><br>\
+        **참고**: 실제 클라이언트가 보내야 하는 데이터 형식은 아래 테이블 참고<br>\
+        <table>\
+          <tr>\
+            <td>이름</td>\
+            <td>타입</td>\
+            <td>필수</td>\
+            <td>설명</td>\
+          </tr>\
+          <tr>\
+            <td>`company`</td>\
+            <td>string</td>\
+            <td>✅</td>\
+            <td>회사명</td>\
+          </tr>\
+          <tr>\
+            <td>`jobTitle`</td>\
+            <td>string</td>\
+            <td>✅</td>\
+            <td>직무명</td>\
+          </tr>\
+          <tr>\
+            <td>`jobSpec`</td>\
+            <td>string</td>\
+            <td>✅</td>\
+            <td>세부 직무 기술</td>\
+          </tr>\
+          <tr>\
+            <td>`coverLetter`</td>\
+            <td>file</td>\
+            <td>✅</td>\
+            <td>자기소개서 (PDF)</td>\
+          </tr>\
+          <tr>\
+            <td>`portfolio`</td>\
+            <td>file</td>\
+            <td>✅</td>\
+            <td>포트폴리오 (PDF)</td>\
+          </tr>\
+          <tr>\
+            <td>`idealTalent`</td>\
+            <td>string</td>\
+            <td>✅</td>\
+            <td>회사의 인재상</td>\
+          </tr>\
+        </table>',
+      consumes: ['multipart/form-data'],
+      body: {
+        type: 'object',
+        properties: {
+          company: {
+            type: 'object',
+            properties: {
+              value: {
+                type: 'string',
+              },
+            },
+          },
+          jobTitle: {
+            type: 'object',
+            properties: {
+              value: {
+                type: 'string',
+              },
+            },
+          },
+          jobSpec: {
+            type: 'object',
+            properties: {
+              value: {
+                type: 'string',
+              },
+            },
+          },
+          coverLetter: { isFile: true },
+          portfolio: { isFile: true },
+          idealTalent: {
+            type: 'object',
+            properties: {
+              value: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        required: [
+          'company',
+          'jobTitle',
+          'jobSpec',
+          'coverLetter',
+          'portfolio',
+          'idealTalent',
+        ],
+      },
+      response: {
+        '201': {
+          description: '성공적으로 면접 세션이 생성되었습니다.',
+          type: 'object',
+          properties: {
+            sessionId: {
+              type: 'string',
+              description: '생성된 면접 세션의 고유 ID',
+            },
+          },
+        },
+        '415': {
+          description:
+            '지원되지 않는 파일 형식입니다. PDF 파일만 업로드할 수 있습니다.',
+          $ref: `${SchemaId.Error}#`,
+        },
+      },
+    },
+  }
+
+  const postHandler: RouteHandlerMethod = async (request, reply) => {
+    const uploadDir = path.join(__dirname, '../../../uploads')
+    if (!fs.existsSync(uploadDir)) {
+      fs.mkdirSync(uploadDir, { recursive: true })
+    }
+
+    let coverLetterPath: string | undefined
+    let portfolioPath: string | undefined
+
+    try {
+      const files = request.files()
+      for await (const part of files) {
+        if (part.mimetype !== 'application/pdf') {
+          throw {
+            statusCode: 415,
+            message: `Unsupported Media Type: '${part.filename}'. Only PDF files are allowed.`,
+          }
+        }
+
+        const uniqueFilename = `${randomUUID()}-${part.filename}`
+        const filePath = path.join(uploadDir, uniqueFilename)
+        await pump(part.file, fs.createWriteStream(filePath))
+
+        if (part.fieldname === 'coverLetter') {
+          coverLetterPath = filePath
+        } else if (part.fieldname === 'portfolio') {
+          portfolioPath = filePath
+        }
+      }
+    } catch (error) {
+      fastify.log.error(error)
+
+      let statusCode = 500
+      let message = 'An error occurred during file processing.'
+      let errorType = 'Internal Server Error'
+
+      // unknown 타입의 에러를 안전하게 처리하기 위한 타입 가드
+      if (typeof error === 'object' && error !== null) {
+        if ('statusCode' in error && typeof error.statusCode === 'number') {
+          statusCode = error.statusCode
+        }
+        if ('message' in error && typeof error.message === 'string') {
+          message = error.message
+        }
+        if (statusCode === 415) {
+          errorType = 'Unsupported Media Type'
+        }
+      }
+
+      return reply.status(statusCode).send({
+        statusCode,
+        error: errorType,
+        message,
+      })
+    }
+
+    // attachFieldsToBody 옵션 덕분에 request.body에서 필드 값을 직접 사용 가능
+    const { company, jobTitle, jobSpec, idealTalent } =
+      request.body as InterviewRequestBody
+
+    console.log(
+      company.value,
+      jobTitle.value.valueOf(),
+      jobSpec.value,
+      idealTalent.value,
+    )
+
+    const session = await fastify.prisma.interviewSession.create({
+      data: {
+        userId: request.user.userId,
+        company: company.value,
+        jobTitle: jobTitle.value,
+        jobSpec: jobSpec.value,
+        idealTalent: idealTalent.value,
+        coverLetter: coverLetterPath,
+        portfolio: portfolioPath,
+      },
+    })
+
+    const askAIForQuestions = async () => {
+      /*
+       * TODO: 프로덕션 확장성 고려
+       * 현재 구현은 core-api 서버가 단일 인스턴스일 때만 정상 동작합니다.
+       * 서버가 여러 대로 확장(scale-out)될 경우, HTTP 요청을 받은 서버와
+       * WebSocket 연결을 유지 중인 서버가 다를 수 있어 클라이언트에게
+       * 결과를 전달하지 못하는 문제가 발생합니다.
+       *
+       * 이를 해결하기 위해 프로덕션 환경에서는 다음과 같은 아키텍처를 권장합니다:
+       * 1. (현재 서버) AI 질문 생성 요청 데이터를 RabbitMQ나 Kafka 같은 메시지 브로커의
+       *    '질문 생성 작업' 큐(토픽)에 발행(publish)합니다.
+       * 2. ai-server는 해당 큐를 구독(subscribe)하여 작업을 가져가 처리합니다.
+       * 3. 작업 완료 후, ai-server는 결과를 '질문 생성 결과' 큐에 발행합니다.
+       * 4. 모든 core-api 인스턴스는 '질문 생성 결과' 큐를 구독하고 있다가,
+       *    결과 메시지를 받으면 Socket.io의 어댑터(예: Redis Adapter)를 통해
+       *    올바른 클라이언트에게 결과를 전송합니다.
+       */
+      try {
+        // 3. (백그라운드 작업) AI 서버에 질문 생성 요청
+        //    현재는 임시로 HTTP 직접 호출을 시뮬레이션합니다.
+        // const questions = await aiServer.generateQuestions(...)
+        const questions = {
+          technical: ['Tell me about REST API.', 'What is WebSocket?'],
+          personality: ['What are your strengths?'],
+          tailored: ['Why do you want to work at our company?'],
+        }
+
+        // 4. AI 서버로부터 받은 질문을 DB에 업데이트
+        await fastify.prisma.interviewSession.update({
+          where: { id: session.id },
+          data: { questions },
+        })
+
+        // 5. 해당 세션의 WebSocket '방(room)'에 있는 클라이언트에게 알림
+        fastify.io.to(session.id).emit('server:questions-ready', { questions })
+      } catch (error) {
+        fastify.log.error(error)
+        fastify.io.to(session.id).emit('server:error', {
+          code: 'AI_GENERATION_FAILED',
+          message: 'Failed to generate interview questions.',
+        })
+      }
+    }
+    askAIForQuestions() // 비동기 함수를 호출하고 기다리지 않습니다.
+
+    reply.status(201).send({ sessionId: session.id })
+  }
+
+  fastify.post(routePath, postOpts, postHandler)
+}
+
+export default interviewsRoute

--- a/apps/core-api/src/routes/api/v1/interviews/index.ts
+++ b/apps/core-api/src/routes/api/v1/interviews/index.ts
@@ -1,274 +1,43 @@
-import { randomUUID } from 'node:crypto'
-import fs from 'node:fs'
-import path from 'node:path'
-import { pipeline } from 'node:stream'
-import { promisify } from 'node:util'
-
 import {
   FastifyPluginAsync,
-  RouteHandlerMethod,
+  RouteHandler,
   RouteShorthandOptions,
 } from 'fastify'
 
 import { Tag } from '@/configs/swaggerOption'
 import SchemaId from '@/utils/schemaId'
 
-const pump = promisify(pipeline)
-
-// request.body에 추가될 필드들의 타입을 정의합니다.
-interface InterviewRequestBody {
-  company: { value: string }
-  jobTitle: { value: string }
-  jobSpec: { value: string }
-  idealTalent: { value: string }
-}
-
-const interviewsRoute: FastifyPluginAsync = async (fastify) => {
-  const routePath = '/'
-
-  const postOpts: RouteShorthandOptions = {
+const route: FastifyPluginAsync = async (fastify) => {
+  const routePath: string = '/'
+  const opts: RouteShorthandOptions = {
     onRequest: [fastify.authenticate],
     schema: {
       tags: [Tag.Interview],
-      summary: '새로운 AI 면접 세션 생성',
-      description:
-        '사용자로부터 회사, 직무, 자기소개서, 포트폴리오, 인재상 등의 정보를 받아 새로운 면접 세션을 생성하고,<br>\
-        백그라운드에서 AI 질문 생성을 시작합니다.<br>\
-        자기소개서와 포트폴리오는 PDF 파일만 업로드 가능합니다.<br><br>\
-        **참고**: 실제 클라이언트가 보내야 하는 데이터 형식은 아래 테이블 참고<br>\
-        <table>\
-          <tr>\
-            <td>이름</td>\
-            <td>타입</td>\
-            <td>필수</td>\
-            <td>설명</td>\
-          </tr>\
-          <tr>\
-            <td>`company`</td>\
-            <td>string</td>\
-            <td>✅</td>\
-            <td>회사명</td>\
-          </tr>\
-          <tr>\
-            <td>`jobTitle`</td>\
-            <td>string</td>\
-            <td>✅</td>\
-            <td>직무명</td>\
-          </tr>\
-          <tr>\
-            <td>`jobSpec`</td>\
-            <td>string</td>\
-            <td>✅</td>\
-            <td>세부 직무 기술</td>\
-          </tr>\
-          <tr>\
-            <td>`coverLetter`</td>\
-            <td>file</td>\
-            <td>✅</td>\
-            <td>자기소개서 (PDF)</td>\
-          </tr>\
-          <tr>\
-            <td>`portfolio`</td>\
-            <td>file</td>\
-            <td>✅</td>\
-            <td>포트폴리오 (PDF)</td>\
-          </tr>\
-          <tr>\
-            <td>`idealTalent`</td>\
-            <td>string</td>\
-            <td>✅</td>\
-            <td>회사의 인재상</td>\
-          </tr>\
-        </table>',
-      consumes: ['multipart/form-data'],
-      body: {
-        type: 'object',
-        properties: {
-          company: {
-            type: 'object',
-            properties: {
-              value: {
-                type: 'string',
-              },
-            },
-          },
-          jobTitle: {
-            type: 'object',
-            properties: {
-              value: {
-                type: 'string',
-              },
-            },
-          },
-          jobSpec: {
-            type: 'object',
-            properties: {
-              value: {
-                type: 'string',
-              },
-            },
-          },
-          coverLetter: { isFile: true },
-          portfolio: { isFile: true },
-          idealTalent: {
-            type: 'object',
-            properties: {
-              value: {
-                type: 'string',
-              },
-            },
-          },
-        },
-        required: [
-          'company',
-          'jobTitle',
-          'jobSpec',
-          'coverLetter',
-          'portfolio',
-          'idealTalent',
-        ],
-      },
+      summary: '사용자가 생성한 모든 면접 세션 목록 조회',
+      description: '사용자가 생성한 면접 세션들의 목록을 반환합니다.',
       response: {
-        '201': {
-          description: '성공적으로 면접 세션이 생성되었습니다.',
-          type: 'object',
-          properties: {
-            sessionId: {
-              type: 'string',
-              description: '생성된 면접 세션의 고유 ID',
-            },
+        '200': {
+          type: 'array',
+          items: {
+            $ref: SchemaId.Interview,
           },
-        },
-        '415': {
-          description:
-            '지원되지 않는 파일 형식입니다. PDF 파일만 업로드할 수 있습니다.',
-          $ref: `${SchemaId.Error}#`,
         },
       },
     },
   }
-
-  const postHandler: RouteHandlerMethod = async (request, reply) => {
-    const uploadDir = path.join(__dirname, '../../../uploads')
-    if (!fs.existsSync(uploadDir)) {
-      fs.mkdirSync(uploadDir, { recursive: true })
-    }
-
-    let coverLetterPath: string | undefined
-    let portfolioPath: string | undefined
-
-    try {
-      const files = request.files()
-      for await (const part of files) {
-        if (part.mimetype !== 'application/pdf') {
-          throw {
-            statusCode: 415,
-            message: `Unsupported Media Type: '${part.filename}'. Only PDF files are allowed.`,
-          }
-        }
-
-        const uniqueFilename = `${randomUUID()}-${part.filename}`
-        const filePath = path.join(uploadDir, uniqueFilename)
-        await pump(part.file, fs.createWriteStream(filePath))
-
-        if (part.fieldname === 'coverLetter') {
-          coverLetterPath = filePath
-        } else if (part.fieldname === 'portfolio') {
-          portfolioPath = filePath
-        }
-      }
-    } catch (error) {
-      fastify.log.error(error)
-
-      let statusCode = 500
-      let message = 'An error occurred during file processing.'
-      let errorType = 'Internal Server Error'
-
-      // unknown 타입의 에러를 안전하게 처리하기 위한 타입 가드
-      if (typeof error === 'object' && error !== null) {
-        if ('statusCode' in error && typeof error.statusCode === 'number') {
-          statusCode = error.statusCode
-        }
-        if ('message' in error && typeof error.message === 'string') {
-          message = error.message
-        }
-        if (statusCode === 415) {
-          errorType = 'Unsupported Media Type'
-        }
-      }
-
-      return reply.status(statusCode).send({
-        statusCode,
-        error: errorType,
-        message,
-      })
-    }
-
-    // attachFieldsToBody 옵션 덕분에 request.body에서 필드 값을 직접 사용 가능
-    const { company, jobTitle, jobSpec, idealTalent } =
-      request.body as InterviewRequestBody
-
-    const session = await fastify.prisma.interviewSession.create({
-      data: {
+  const handler: RouteHandler = async (request, reply) => {
+    const sessions = await fastify.prisma.interviewSession.findMany({
+      where: {
         userId: request.user.userId,
-        company: company.value,
-        jobTitle: jobTitle.value,
-        jobSpec: jobSpec.value,
-        idealTalent: idealTalent.value,
-        coverLetter: coverLetterPath,
-        portfolio: portfolioPath,
+        currentQuestionIndex: 0,
+      },
+      orderBy: {
+        createdAt: 'desc', // 최신순으로 정렬
       },
     })
-
-    const askAIForQuestions = async () => {
-      /*
-       * TODO: 프로덕션 확장성 고려
-       * 현재 구현은 core-api 서버가 단일 인스턴스일 때만 정상 동작합니다.
-       * 서버가 여러 대로 확장(scale-out)될 경우, HTTP 요청을 받은 서버와
-       * WebSocket 연결을 유지 중인 서버가 다를 수 있어 클라이언트에게
-       * 결과를 전달하지 못하는 문제가 발생합니다.
-       *
-       * 이를 해결하기 위해 프로덕션 환경에서는 다음과 같은 아키텍처를 권장합니다:
-       * 1. (현재 서버) AI 질문 생성 요청 데이터를 RabbitMQ나 Kafka 같은 메시지 브로커의
-       *    '질문 생성 작업' 큐(토픽)에 발행(publish)합니다.
-       * 2. ai-server는 해당 큐를 구독(subscribe)하여 작업을 가져가 처리합니다.
-       * 3. 작업 완료 후, ai-server는 결과를 '질문 생성 결과' 큐에 발행합니다.
-       * 4. 모든 core-api 인스턴스는 '질문 생성 결과' 큐를 구독하고 있다가,
-       *    결과 메시지를 받으면 Socket.io의 어댑터(예: Redis Adapter)를 통해
-       *    올바른 클라이언트에게 결과를 전송합니다.
-       */
-      try {
-        // 3. (백그라운드 작업) AI 서버에 질문 생성 요청
-        //    현재는 임시로 HTTP 직접 호출을 시뮬레이션합니다.
-        // const questions = await aiServer.generateQuestions(...)
-        const questions = {
-          technical: ['Tell me about REST API.', 'What is WebSocket?'],
-          personality: ['What are your strengths?'],
-          tailored: ['Why do you want to work at our company?'],
-        }
-
-        // 4. AI 서버로부터 받은 질문을 DB에 업데이트
-        await fastify.prisma.interviewSession.update({
-          where: { id: session.id },
-          data: { questions },
-        })
-
-        // 5. 해당 세션의 WebSocket '방(room)'에 있는 클라이언트에게 알림
-        fastify.io.to(session.id).emit('server:questions-ready', { questions })
-      } catch (error) {
-        fastify.log.error(error)
-        fastify.io.to(session.id).emit('server:error', {
-          code: 'AI_GENERATION_FAILED',
-          message: 'Failed to generate interview questions.',
-        })
-      }
-    }
-    askAIForQuestions() // 비동기 함수를 호출하고 기다리지 않습니다.
-
-    reply.status(201).send({ sessionId: session.id })
+    reply.send(sessions)
   }
 
-  fastify.post(routePath, postOpts, postHandler)
+  fastify.get(routePath, opts, handler)
 }
-
-export default interviewsRoute
+export default route

--- a/apps/core-api/src/schemas/rest/index.ts
+++ b/apps/core-api/src/schemas/rest/index.ts
@@ -1,3 +1,4 @@
 export * from './error'
 export * from './user'
 export * from './interface'
+export * from './interview'

--- a/apps/core-api/src/schemas/rest/interview.ts
+++ b/apps/core-api/src/schemas/rest/interview.ts
@@ -1,0 +1,39 @@
+import ISchema from '@/schemas/rest/interface'
+import SchemaId from '@/utils/schemaId'
+
+export const interviewSchema: ISchema = {
+  $id: SchemaId.Interview,
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+      description: '면접 세션의 고유 ID',
+      example: 'clxxtkv0w0000a4z0b1c2d3e4',
+    },
+    company: {
+      type: 'string',
+      description: '회사명',
+      example: 'Awesome Inc.',
+    },
+    jobTitle: {
+      type: 'string',
+      description: '직무명',
+      example: 'Software Engineer',
+    },
+    currentQuestionIndex: {
+      type: 'number',
+      description: '현재 진행 중인 질문의 인덱스 (0부터 시작)',
+      example: 0,
+    },
+    createdAt: {
+      type: 'string',
+      format: 'date-time',
+      description: '생성 일시',
+    },
+    updatedAt: {
+      type: 'string',
+      format: 'date-time',
+      description: '마지막 업데이트 일시',
+    },
+  },
+}

--- a/apps/core-api/src/server.ts
+++ b/apps/core-api/src/server.ts
@@ -45,12 +45,15 @@ const start = async () => {
   // Autoload plugins
   await app.register(AutoLoad, {
     dir: join(__dirname, 'plugins'),
+    dirNameRoutePrefix: true,
     options: {},
   })
 
   // Autoload routes
   await app.register(AutoLoad, {
     dir: join(__dirname, 'routes'),
+    dirNameRoutePrefix: true,
+    routeParams: true,
     options: {},
   })
 

--- a/apps/core-api/src/utils/schemaId.ts
+++ b/apps/core-api/src/utils/schemaId.ts
@@ -2,6 +2,7 @@ enum SchemaId {
   // REST Schemas
   Error = 'ErrorResponse',
   User = 'UserResponse',
+  Interview = 'InterviewResponse',
 
   // WebSocket Schemas
   WsClientReady = 'WsClientReady',


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-31](https://konkuk-graduation-project.atlassian.net/browse/AIEW-31)
- **Branch**: feature/AIEW-31

---

### 작업 내용 📌

- DB 스키마 변경 (`currentQuestionIndex`)
  - 사용자가 면접 세션만 생성하고 실제 연습은 진행하지 않았을 수 있음
  - 이를 추적하기 위해 면접 세션 별로 몇 번째 질문까지 답변했는지 저장
- 경로명 라우팅 기능으로 파라미터를 받을 수 있도록 셋업
- `interviewSession`을 조회할 수 있는 API 추가
  - 전체 조회
    - `GET /interviews` 
  - 단일 조회
    - `GET /interviews/{sessionId}` 
- `POST /interviews`는 `POST /interviews/create`로 변경
---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행 후 http://localhost:3000/docs#/%F0%9F%97%A3%EF%B8%8F%20%EB%A9%B4%EC%A0%91 접속
- `pnpm -F core-api prisma studio`를 통해 `sessionId`를 복사 후 활용
  - 옵션 안 주면 `schema`랑 `db`를 못 찾으니 주의

---

### 참고 사항 📂

- https://www.npmjs.com/package/@fastify/autoload
- https://www.prisma.io/studio#try-locally


[AIEW-31]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ