### PR TITLE
Aiew 57 pdf 파싱 및 전처리 결과 세션에 저장

### DIFF
--- a/apps/ai-server/app/api/v1/endpoints/memory_debug.py
+++ b/apps/ai-server/app/api/v1/endpoints/memory_debug.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, Header, HTTPException
+from langchain.memory import ConversationBufferMemory
+from pydantic import BaseModel
+from typing import List, Literal
+
+from app.core.memory import get_memory
+
+
+router = APIRouter()
+
+# 세션별 메모리 주입 (X-Session-Id 헤더 사용)
+def MemoryDep(x_session_id: str = Header(default=None)) -> ConversationBufferMemory:
+    if not x_session_id:
+        raise HTTPException(status_code=400, detail="X-Session-Id header required")
+    return get_memory(x_session_id)
+
+class Message(BaseModel):
+    role: Literal["human", "ai", "system"] = "human"
+    content: str
+
+class MemoryDump(BaseModel):
+    session_id: str
+    history_str: str               # ConversationBufferMemory가 합쳐서 내주는 문자열
+    messages: List[Message]        # 원본 메시지 배열 (role, content)
+
+@router.get("/dump", response_model=MemoryDump)
+def get_memory_dump(
+    memory: ConversationBufferMemory = Depends(MemoryDep),
+    x_session_id: str = Header(default=None),
+):
+    """
+    현재 세션의 메모리 전체를 반환:
+    - history_str: LangChain이 합쳐서 관리하는 히스토리 문자열
+    - messages: 내부 메시지 배열(역직렬화 용이)
+    """
+    # history_str 가져오기
+    vars = memory.load_memory_variables({"input": ""})
+    history_str = vars.get("history", "")
+
+    # 원본 messages 배열 가져오기
+    msgs = getattr(memory, "chat_memory", None)
+    messages_out: List[Message] = []
+    if msgs and getattr(msgs, "messages", None):
+        for m in msgs.messages:
+            role = "human"
+            # HumanMessage / AIMessage / SystemMessage 타입명으로 role 매핑
+            t = type(m).__name__.lower()
+            if "ai" in t:
+                role = "ai"
+            elif "system" in t:
+                role = "system"
+            messages_out.append(Message(role=role, content=str(m.content)))
+
+    return MemoryDump(
+        session_id=x_session_id, 
+        history_str=history_str, 
+        messages=messages_out
+    )
+
+@router.delete("/reset")
+def reset_memory(memory: ConversationBufferMemory = Depends(MemoryDep)):
+    """
+    현재 세션 메모리를 초기화합니다.
+    """
+    memory.clear()
+    return {"ok": True, "message": "memory cleared"}

--- a/apps/ai-server/app/api/v1/endpoints/pdf.py
+++ b/apps/ai-server/app/api/v1/endpoints/pdf.py
@@ -1,24 +1,47 @@
-from fastapi import APIRouter, File, UploadFile
+import json
+from fastapi import APIRouter, File, UploadFile, Depends
+from langchain.memory import ConversationBufferMemory
 
 from app.models.pdf import PDFUploadResponse
 from app.services.ocr_parser import extract_text_from_image_pdf
 from app.services.pdf_parser import extract_text_from_digital_pdf
 from app.services.preprocessor import preprocess_text
 from app.utils.file_check import is_digital_pdf
+from app.api.v1.endpoints.memory_debug import MemoryDep
 
 router = APIRouter()
 
 
 @router.post("/pdf-text-parsing", response_model=PDFUploadResponse)
-async def parse_pdf_text(file: UploadFile = File(...)):
+async def parse_pdf_text(file: UploadFile = File(...), memory: ConversationBufferMemory = Depends(MemoryDep), ):
     file_bytes = await file.read()
 
-    if is_digital_pdf(file_bytes):
-        extracted_text = extract_text_from_digital_pdf(file_bytes)
-    else:
-        extracted_text = extract_text_from_image_pdf(file_bytes)
-
+    digital = is_digital_pdf(file_bytes)
+    extracted_text = (
+        extract_text_from_digital_pdf(file_bytes)
+        if digital else
+        extract_text_from_image_pdf(file_bytes)
+    )
+    
     preprocessed_sentences = preprocess_text(extracted_text)
+
+    try:
+        preview = ""
+        if isinstance(extracted_text, str):
+            preview = extracted_text[:400] + ("…" if len(extracted_text) > 400 else "")
+        memory.save_context(
+            {"input": "[PDF_PARSE]"},
+            {"output": json.dumps({
+                "filename": file.filename,
+                "digital": digital,
+                "chars": len(extracted_text) if isinstance(extracted_text, str) else None,
+                "sentences": len(preprocessed_sentences) if isinstance(preprocessed_sentences, list) else None,
+                "preview": preview
+            }, ensure_ascii=False)}
+        )
+    except Exception:
+        # 메모리 로깅 실패해도 파싱 결과는 반환
+        pass
 
     return PDFUploadResponse(
         filename=file.filename, extracted_text=preprocessed_sentences

--- a/apps/ai-server/app/api/v1/endpoints/session_log.py
+++ b/apps/ai-server/app/api/v1/endpoints/session_log.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel, Field
+from langchain.memory import ConversationBufferMemory
+
+from app.core.memory import get_memory
+from app.services.memory_logger import log_shown_question, log_user_answer
+
+
+router = APIRouter()
+
+def MemoryDep(x_session_id: str = Header(default=None)) -> ConversationBufferMemory:
+    """X-Session-Id 헤더로 세션별 메모리 주입"""
+    if not x_session_id:
+        raise HTTPException(status_code=400, detail="X-Session-Id header required")
+    return get_memory(x_session_id)
+
+class ShownQuestion(BaseModel):
+    question: dict
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "question": {
+                    "main_question_id": "q2",
+                    "category": "technical",
+                    "criteria": ["명확성", "깊이", "근거"],
+                    "skills": ["React", "TypeScript"],
+                    "rationale": "컴포넌트 설계 역량 검증",
+                    "question_text": "React와 TypeScript로 UI 컴포넌트를 설계할 때 고려하는 사항은?",
+                    "estimated_answer_time_sec": 90
+                }
+            }
+        }
+    }
+
+class UserAnswer(BaseModel):
+    question_id: str = Field(..., pattern=r"^q\d+(-fu\d+)?$")
+    answer: str
+    answer_duration_sec: int
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "question_id": "q2",
+                "answer": "컴포넌트는 작게 분리하고 제네릭 타입으로 인터페이스를 추상화합니다...",
+                "answer_duration_sec": 72
+            }
+        }
+    }
+
+@router.post("/log/question-shown")
+def post_question_shown(
+    payload: ShownQuestion, 
+    memory: ConversationBufferMemory = Depends(MemoryDep)
+):
+    log_shown_question(memory, payload.question)
+    return  {"ok": True}
+
+@router.post("/log/user-answer")
+def post_user_answer(
+    payload: UserAnswer, 
+    memory: ConversationBufferMemory = Depends(MemoryDep)
+):
+    log_user_answer(
+        memory, 
+        payload.question_id, 
+        payload.answer, 
+        payload.answer_duration_sec
+    )
+    return {"ok": True}

--- a/apps/ai-server/app/core/memory.py
+++ b/apps/ai-server/app/core/memory.py
@@ -1,0 +1,16 @@
+from typing import Dict
+from langchain.memory import ConversationBufferMemory
+
+
+_memory_store: Dict[str, ConversationBufferMemory] = {}
+
+def get_memory(session_id: str) -> ConversationBufferMemory:
+    """세션 ID별로 LangChain Memory를 생성/반환"""
+    if session_id not in _memory_store:
+        _memory_store[session_id] = ConversationBufferMemory(
+            memory_key="history",
+            input_key="input",
+            output_key="output",
+            return_messages=False
+        )
+    return _memory_store[session_id]

--- a/apps/ai-server/app/main.py
+++ b/apps/ai-server/app/main.py
@@ -1,12 +1,16 @@
 from fastapi import FastAPI
 
-from app.api.v1.endpoints import pdf, question
+from app.api.v1.endpoints import pdf, question, followup, evaluation, session_log, memory_debug
+
 
 app = FastAPI()
 
-app.include_router(pdf.router, prefix="/api/v1/pdf", tags=["pdf"])
-app.include_router(question.router, prefix="/api/v1/question", tags=["question"])
-
+app.include_router(session_log.router, prefix="/api/v1/session-log", tags=["Session Log"])
+app.include_router(pdf.router, prefix="/api/v1/pdf", tags=["PDF"])
+app.include_router(question.router, prefix="/api/v1/question", tags=["Question"])
+app.include_router(followup.router, prefix="/api/v1/followup", tags=["Question"])
+app.include_router(evaluation.router, prefix="/api/v1/evaluation", tags=["Evaluation"])
+app.include_router(memory_debug.router, prefix="/api/v1/memory-debug", tags=["Memory Debug"])
 
 @app.get("/")
 def read_root():

--- a/apps/ai-server/app/services/memory_logger.py
+++ b/apps/ai-server/app/services/memory_logger.py
@@ -1,0 +1,31 @@
+import json
+from typing import Any, Dict, List
+from langchain.memory import ConversationBufferMemory
+
+
+def _log(memory: ConversationBufferMemory, title: str, payload: Dict[str, Any]) -> None:
+    """텍스트 로그 + 구조화 JSON 함께 메모리에 저장"""
+    pretty = json.dumps(payload, ensure_ascii=False)
+    memory.save_context(
+        {"input": f"[{title}]"},
+        {"output": pretty[:4000]}  # 너무 긴 경우 4000자까지만
+    )
+
+def log_main_questions(memory: ConversationBufferMemory, questions: List[Dict[str, Any]]) -> None:
+    _log(memory, "MAIN_QUESTIONS", {"count": len(questions), "items": questions})
+
+def log_shown_question(memory: ConversationBufferMemory, q: Dict[str, Any]) -> None:
+    _log(memory, "QUESTION_SHOWN", q)
+
+def log_user_answer(memory: ConversationBufferMemory, question_id: str, answer: str, duration_sec: int) -> None:
+    _log(memory, "USER_ANSWER", {
+        "question_id": question_id,
+        "answer": answer,
+        "answer_duration_sec": duration_sec
+    })
+
+def log_evaluation(memory: ConversationBufferMemory, evaluation: Dict[str, Any]) -> None:
+    _log(memory, "ANSWER_EVALUATION", evaluation)
+
+def log_tail_question(memory: ConversationBufferMemory, followup: Dict[str, Any]) -> None:
+    _log(memory, "TAIL_QUESTION", followup)

--- a/apps/ai-server/app/services/preprocessor.py
+++ b/apps/ai-server/app/services/preprocessor.py
@@ -16,7 +16,7 @@ def preprocess_text(text: str) -> str:
 
         # 빈 줄은 문단 구분 기호로 치환
         if not line:
-            processed_text += "<br>"
+            processed_text += "\n"
             i += 1
             continue
 


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-57](https://konkuk-graduation-project.atlassian.net/browse/AIEW-57)
- **Branch**: feature/AIEW-57

---

### 작업 내용 📌

- 파싱된 텍스트 전처리 시 줄바꿈 표시 기호 변경
- 세션 아이디(`X-Session-Id`) 요청 필수화 및 파싱 로그 메모리에 저장
  - `MemoryDep` 의존성 주입으로 세션 아이디 필수
  - 파싱 결과 메타정보(파일명, 타입, 길이, 미리보기) 세션 메모리에 누적 저장

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행 후 테스트

1. Jira에서 resume_digital.pdf, portfolio_digital.pdf다운로드 
2. Swagger에서 `/pdf-text-parsing` 엔드포인트 선택
3. `X-Session-Id` 헤더에 UUID 입력  
   예: `123e4567-e89b-12d3-a456-426614174000`
   (추후 백이나 프론트에서 전달받아야 함)
4. PDF 파일 업로드 (디지털/이미지 각각 테스트)
5. 응답으로 전처리된 텍스트 및 세션 메모리 기록 확인

---

### 참고 사항

**Session Log:** 
역할: 세션 메모리에 “특정 이벤트”를 기록하는 쓰기(write) 전용 API
“이 질문을 언제 보여줬는지, 어떤 답을 했는지” 같은 면접 진행 로그 누적

주요 엔드포인트:
- /session/log/question-shown → 질문이 화면에 표시된 시점 기록
- /session/log/user-answer → 사용자가 답변한 내용과 시간 기록

동작:
1. 요청 바디에 해당 이벤트의 데이터(질문 객체나 답변 내용)를 담아서 전송
2. MemoryDep를 통해 세션 ID 기반의 메모리를 불러옴
3. 해당 메모리에 save_context()로 이벤트 데이터 저장


**Memory Debug**
역할: 세션 메모리에 쌓인 데이터를 읽기(read) / 초기화(reset) 하는 디버그용 API

주요 엔드포인트:
- GET /memory-debug/dump → 현재 세션 메모리에 누적된 모든 기록을 조회
- DELETE /memory-debug/reset → 현재 세션 메모리를 전부 초기화

동작:
- dump는 memory.chat_memory.messages를 그대로 반환
- reset은 해당 세션 ID에 해당하는 메모리 객체를 비우거나 제거


[AIEW-57]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ