### PR TITLE
[AIEW-53] 답변 DB 스키마 구성

### DIFF
--- a/apps/core-api/prisma/migrations/20250812025640_add_interview_step/migration.sql
+++ b/apps/core-api/prisma/migrations/20250812025640_add_interview_step/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `questions` on the `InterviewSession` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "QuestionType" AS ENUM ('TECHNICAL', 'PERSONALITY', 'TAILORED');
+
+-- DropForeignKey
+ALTER TABLE "InterviewSession" DROP CONSTRAINT "InterviewSession_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "InterviewSession" DROP COLUMN "questions",
+ADD COLUMN     "finalFeedback" TEXT;
+
+-- CreateTable
+CREATE TABLE "InterviewStep" (
+    "id" TEXT NOT NULL,
+    "type" "QuestionType" NOT NULL,
+    "question" TEXT NOT NULL,
+    "answer" TEXT,
+    "feedback" TEXT,
+    "score" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "interviewSessionId" TEXT NOT NULL,
+    "parentStepId" TEXT,
+
+    CONSTRAINT "InterviewStep_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "InterviewSession" ADD CONSTRAINT "InterviewSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InterviewStep" ADD CONSTRAINT "InterviewStep_interviewSessionId_fkey" FOREIGN KEY ("interviewSessionId") REFERENCES "InterviewSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InterviewStep" ADD CONSTRAINT "InterviewStep_parentStepId_fkey" FOREIGN KEY ("parentStepId") REFERENCES "InterviewStep"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/apps/core-api/prisma/migrations/20250823105018_add_detailed_evaluation_fields/migration.sql
+++ b/apps/core-api/prisma/migrations/20250823105018_add_detailed_evaluation_fields/migration.sql
@@ -1,0 +1,37 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `feedback` on the `InterviewStep` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "InterviewStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED');
+
+-- AlterTable
+ALTER TABLE "InterviewSession" ADD COLUMN     "status" "InterviewStatus" NOT NULL DEFAULT 'NOT_STARTED',
+ADD COLUMN     "totalTimeSec" INTEGER;
+
+-- AlterTable
+ALTER TABLE "InterviewStep" DROP COLUMN "feedback",
+ADD COLUMN     "answerDurationSec" INTEGER,
+ADD COLUMN     "criteria" TEXT[],
+ADD COLUMN     "estimatedAnswerTimeSec" INTEGER,
+ADD COLUMN     "improvements" TEXT[],
+ADD COLUMN     "rationale" TEXT,
+ADD COLUMN     "redFlags" TEXT[],
+ADD COLUMN     "skills" TEXT[],
+ADD COLUMN     "strengths" TEXT[];
+
+-- CreateTable
+CREATE TABLE "CriterionEvaluation" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "interviewStepId" TEXT NOT NULL,
+
+    CONSTRAINT "CriterionEvaluation_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "CriterionEvaluation" ADD CONSTRAINT "CriterionEvaluation_interviewStepId_fkey" FOREIGN KEY ("interviewStepId") REFERENCES "InterviewStep"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -20,6 +20,13 @@ enum QuestionType {
   TAILORED
 }
 
+// ++ 추가: 면접 세션의 진행 상태를 나타내는 Enum
+enum InterviewStatus {
+  NOT_STARTED // 생성만 되고 아직 시작 안 함
+  IN_PROGRESS // 진행 중
+  COMPLETED   // 모든 질문에 답변 완료
+}
+
 model User {
   id                String             @id @default(cuid())
   email             String             @unique
@@ -46,6 +53,10 @@ model InterviewSession {
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 
+  // ++ 추가: 면접 진행 상태 및 전체 시간
+  status               InterviewStatus @default(NOT_STARTED)
+  totalTimeSec         Int?            // 면접 전체 제한 시간 (초)
+
   // Relations
   user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId  String
@@ -58,10 +69,21 @@ model InterviewStep {
   type      QuestionType // 질문 유형 (기술, 인성, 맞춤)
   question  String       // AI가 생성한 질문 내용
   answer    String?      // 사용자의 답변 내용
-  feedback  String?      // 답변에 대한 AI의 자연어 평가
-  score     Int?         // 답변에 대한 수치화된 점수 (0-100)
+  score     Int?         // AI가 평가한 총점 (0-100)
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
+
+  // ++ 추가: 질문 생성 시의 메타데이터
+  rationale              String?   // 질문 선정 근거
+  criteria               String[]  // 평가 기준 키워드 목록
+  skills                 String[]  // 측정 역량 태그 목록
+  estimatedAnswerTimeSec Int?      // 예상 답변 시간 (초)
+
+  // ++ 추가: 답변 및 평가에 대한 상세 정보
+  answerDurationSec      Int?      // 실제 사용자 답변 시간 (초)
+  strengths              String[]  // AI가 평가한 강점 목록
+  improvements           String[]  // AI가 평가한 개선점 목록
+  redFlags               String[]  // AI가 발견한 위험 신호 목록
 
   // --- 관계 정의 ---
 
@@ -77,4 +99,19 @@ model InterviewStep {
   // 이 필드가 존재하면 꼬리 질문임
   parentStep     InterviewStep?  @relation("FollowUp", fields: [parentStepId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   parentStepId   String?
+
+  // ++ 추가: 세부 평가 기준 점수와의 관계
+  criterionEvaluations CriterionEvaluation[]
+}
+
+// ++ 신규 모델: 세부 평가 기준별 점수를 저장하는 모델
+model CriterionEvaluation {
+  id        String @id @default(cuid())
+  name      String // 평가 기준명 (예: 명확성, 깊이)
+  score     Int    // 1~5 정수 점수
+  reason    String // 해당 기준 점수 부여 이유
+
+  // Relations
+  interviewStep   InterviewStep @relation(fields: [interviewStepId], references: [id], onDelete: Cascade)
+  interviewStepId String
 }

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -13,33 +13,68 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// 질문의 종류를 나타내는 Enum
+enum QuestionType {
+  TECHNICAL
+  PERSONALITY
+  TAILORED
+}
+
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String?
-  pic_url   String   @default("https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=mail@ashallendesign.co.uk")
-  provider  String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                String             @id @default(cuid())
+  email             String             @unique
+  name              String?
+  pic_url           String             @default("https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=mail@ashallendesign.co.uk")
+  provider          String
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
 
   // Relation to InterviewSession
   interviewSessions InterviewSession[]
 }
 
 model InterviewSession {
-  id           String @id @default(cuid())
-  company      String
-  jobTitle     String
-  jobSpec      String
-  idealTalent  String?
-  coverLetter  String? // Path to the stored file
-  portfolio    String? // Path to the stored file
-  questions    Json?   // AI-generated questions
+  id                   String   @id @default(cuid())
+  company              String
+  jobTitle             String
+  jobSpec              String
+  idealTalent          String?
+  coverLetter          String? // Path to the stored file
+  portfolio            String? // Path to the stored file
   currentQuestionIndex Int      @default(0)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  finalFeedback        String? // 모든 면접 완료 후 생성될 총평
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
 
-  // Relation to User
-  user   User   @relation(fields: [userId], references: [id])
-  userId String
+  // Relations
+  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId  String
+  steps   InterviewStep[] // 이 세션에 속한 모든 질문/답변 목록
+}
+
+// 질문과 답변, 평가를 한 세트로 묶는 모델
+model InterviewStep {
+  id        String       @id @default(cuid())
+  type      QuestionType // 질문 유형 (기술, 인성, 맞춤)
+  question  String       // AI가 생성한 질문 내용
+  answer    String?      // 사용자의 답변 내용
+  feedback  String?      // 답변에 대한 AI의 자연어 평가
+  score     Int?         // 답변에 대한 수치화된 점수 (0-100)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  // --- 관계 정의 ---
+
+  // 1. InterviewSession과의 관계 (Many-to-One)
+  interviewSession   InterviewSession @relation(fields: [interviewSessionId], references: [id], onDelete: Cascade)
+  interviewSessionId String
+
+  // 2. 꼬리 질문을 위한 자기 참조 관계 (One-to-Many)
+  // 이 단계로부터 파생된 꼬리 질문 단계 목록
+  tailSteps      InterviewStep[] @relation("FollowUp")
+  
+  // 이 단계가 어떤 부모 단계로부터 파생된 꼬리 질문인지 명시
+  // 이 필드가 존재하면 꼬리 질문임
+  parentStep     InterviewStep?  @relation("FollowUp", fields: [parentStepId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  parentStepId   String?
 }

--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -42,14 +42,14 @@ const socketIOPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
     try {
       // DB를 조회하여 질문이 이미 생성되었는지 확인합니다.
-      const session = await fastify.prisma.interviewSession.findUnique({
-        where: { id: sessionId },
-        select: { questions: true },
+      const steps = await fastify.prisma.interviewStep.findMany({
+        where: { interviewSessionId: sessionId },
+        orderBy: { createdAt: 'asc' },
       })
 
-      // 질문이 이미 존재한다면, 즉시 해당 클라이언트에게 전송합니다.
-      if (session?.questions) {
-        socket.emit('server:questions-ready', { questions: session.questions })
+      // 질문(steps)이 이미 존재한다면, 즉시 해당 클라이언트에게 전송합니다.
+      if (steps.length > 0) {
+        socket.emit('server:questions-ready', { steps })
       }
     } catch (error) {
       fastify.log.error(

--- a/apps/core-api/src/schemas/rest/error.ts
+++ b/apps/core-api/src/schemas/rest/error.ts
@@ -1,6 +1,8 @@
+import ISchema from './interface'
+
 import SchemaId from '@/utils/schemaId'
 
-export const errorSchema = {
+export const errorSchema: ISchema = {
   $id: SchemaId.Error,
   type: 'object',
   properties: {

--- a/apps/core-api/src/schemas/ws/interview.dto.ts
+++ b/apps/core-api/src/schemas/ws/interview.dto.ts
@@ -18,11 +18,19 @@ export interface WebSocketMessage<T> {
  * 질문 생성이 완료되었음을 알리는 메시지
  */
 export interface QuestionsReadyPayload {
-  questions: {
-    technical: string[]
-    personality: string[]
-    tailored: string[]
-  }
+  steps: {
+    id: string
+    type: 'TECHNICAL' | 'PERSONALITY' | 'TAILORED'
+    question: string
+    // 초기 질문에는 답변, 피드백 등이 없으므로 optional
+    answer?: string | null
+    feedback?: string | null
+    score?: number | null
+    createdAt: Date
+    updatedAt: Date
+    interviewSessionId: string
+    parentStepId?: string | null
+  }[]
 }
 export type ServerQuestionsReadyMessage =
   WebSocketMessage<QuestionsReadyPayload>
@@ -74,44 +82,37 @@ export const wsServerQuestionsReadySchema = {
     payload: {
       type: 'object',
       properties: {
-        questions: {
-          type: 'object',
-          properties: {
-            technical: {
-              type: 'array',
-              items: {
+        steps: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              type: {
                 type: 'string',
-                const: [
-                  '저희 서비스에서 사용 중인 Fastify의 장단점에 대해 설명해주세요.',
-                  'HTTP와 WebSocket의 차이점을 설명하고, 어떤 상황에서 각각을 사용해야 할까요?',
-                ],
+                enum: ['TECHNICAL', 'PERSONALITY', 'TAILORED'],
               },
+              question: { type: 'string' },
+              answer: { type: ['string', 'null'] },
+              feedback: { type: ['string', 'null'] },
+              score: { type: ['integer', 'null'] },
+              createdAt: { type: 'string', format: 'date-time' },
+              updatedAt: { type: 'string', format: 'date-time' },
+              interviewSessionId: { type: 'string' },
+              parentStepId: { type: ['string', 'null'] },
             },
-            personality: {
-              type: 'array',
-              items: {
-                type: 'string',
-                const: [
-                  '가장 어려웠던 협업 경험은 무엇이며, 어떻게 해결했나요?',
-                  '스트레스를 관리하는 자신만의 방법이 있나요?',
-                ],
-              },
-            },
-            tailored: {
-              type: 'array',
-              items: {
-                type: 'string',
-                const: [
-                  '제출하신 포트폴리오의 인증 시스템에서 Refresh Token의 역할을 더 자세히 설명해주세요.',
-                  "저희 회사의 인재상인 '끊임없는 학습'을 실천했던 경험이 있다면 말씀해주세요.",
-                ],
-              },
-            },
+            required: [
+              'id',
+              'type',
+              'question',
+              'createdAt',
+              'updatedAt',
+              'interviewSessionId',
+            ],
           },
-          required: ['technical', 'personality', 'tailored'],
         },
       },
-      required: ['questions'],
+      required: ['steps'],
     },
   },
   required: ['type', 'payload'],


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-53](https://konkuk-graduation-project.atlassian.net/browse/AIEW-53)
- **Branch**: feature/AIEW-53

---

### 작업 내용 📌

- 실제 면접에서 사용될, 질문과 답변이 한 세트로 묶인 `InterviewStep` 테이블 생성
- `User`
  - 변경 사항 없음
- `InterviewSession`
  - 기존 `InterviewSession` 모델 속 JSON 형식의 questions 필드 삭제
  - 모든 면접 완료 후의 총평이 담길 `finalFeedback` 필드 추가
- `InterviewStep`
  - 질문, 답변, 자연어로 구성된 평가, 수치화된 점수 등
  - with `InterviewSession` -> Many-to-One
  - with `tailSteps` -> One-to-Many
- **추가 변경 사항**
  - `InterviewStatus` enum 추가: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`
  - `InterviewSession`
    - `status` 필드 추가 (진행 상태)
    - `totalTimeSec` 필드 추가 (총 제한 시간)
  - `InterviewStep`
    - 질문 메타데이터 필드 추가: `rationale`, `criteria`, `skills`, `estimatedAnswerTimeSec`
    - 답변/평가 상세 필드 추가: `answerDurationSec`, `strengths`, `improvements`, `redFlags`
  - `CriterionEvaluation` 모델 추가
    - 세부 평가 기준별 점수(`name`, `score`, `reason`) 저장
    - with `InterviewStep` -> Many-to-One

---

### 테스트 방법 🧑🏻‍🔬

- [AIew/Development/Studio](https://console.prisma.io/htr9n1yjymu2pawsvxfpmn0q/cme2venx00e7z3q0v7nu0o0pc/cme2venx00e7x3q0vc6m5v3d1/studio) 에서 변경된 스키마 확인

---

### 참고 사항 📂

- 필드는 회의에서 의논 후 추가될 수 있음
- 해당 브랜치가 merge된 이후에는 각자의 개발환경에서 아래 명령어를 순차적으로 실행
```shell
git switch develop
git fetch
git pull
pnpm -F core-api exec prisma migrate deploy
``` 


[AIEW-53]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ