### PR TITLE
[AIEW-60 꼬리질문 생성]

### DIFF
--- a/apps/ai-server/app/api/v1/endpoints/followup.py
+++ b/apps/ai-server/app/api/v1/endpoints/followup.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from langchain.memory import ConversationBufferMemory
+
+from app.api.v1.endpoints.memory_debug import MemoryDep
+from app.models.followup import Followup, FollowupRequest
+from app.services.followup_generator import generate_followups
+
+router = APIRouter()
+
+
+@router.post("/followup-generating", response_model=Followup)
+def generate_followup(
+    req: FollowupRequest, memory: ConversationBufferMemory = Depends(MemoryDep)
+):
+    followup = generate_followups(req, memory)
+    return followup

--- a/apps/ai-server/app/config/prompt/followup_prompt.txt
+++ b/apps/ai-server/app/config/prompt/followup_prompt.txt
@@ -1,0 +1,41 @@
+당신은 웹개발자 면접관으로서, 
+아래 컨텍스트를 바탕으로 "정확히 1개"의 꼬리질문을 생성합니다.
+
+[부모 질문]
+- 질문 ID: {question_id}
+- 카테고리: {category}
+- 본문: {question_text}
+
+[평가 기준]: {criteria_csv}
+[역량 태그]: {skills_csv}
+
+[사용자 답변]
+{user_answer}
+
+[평가 요약]
+{evaluation_summary}
+
+[제약]
+- 남은 시간(초): {remaining_time_sec}
+- 남은 메인 질문 수: {remaining_main_questions}
+- 추궁 강도(depth): {depth}
+
+요구사항:
+- Yes/No로 답할 수 있는 형태 금지
+- 중복/모호 금지, 구체적 근거 유도
+- 시간이 부족할수록 더 짧고 날카롭게
+- depth가 높을수록 더 집요하게 구체 예시나 수치, 코드/로그/지표를 요구
+
+출력 규칙:
+- 설명(평가기준, 이유 등)과 질문 본문은 한글로 작성.
+- 반드시 JSON만 출력. 설명/마크다운 금지.
+
+출력 예시:
+{{
+  "followup_id": "string",
+  "parent_question_id": "string",
+  "focus_criteria": ["string"],
+  "rationale": "string",
+  "question_text": "string",
+  "expected_answer_time_sec": 45
+}}

--- a/apps/ai-server/app/main.py
+++ b/apps/ai-server/app/main.py
@@ -1,6 +1,13 @@
 from fastapi import FastAPI
 
-from app.api.v1.endpoints import evaluation, memory_debug, pdf, question, session_log
+from app.api.v1.endpoints import (
+    evaluation,
+    followup,
+    memory_debug,
+    pdf,
+    question,
+    session_log,
+)
 
 app = FastAPI()
 
@@ -10,6 +17,7 @@ app.include_router(
 app.include_router(pdf.router, prefix="/api/v1/pdf", tags=["PDF"])
 app.include_router(question.router, prefix="/api/v1/question", tags=["Question"])
 app.include_router(evaluation.router, prefix="/api/v1/evaluation", tags=["Evaluation"])
+app.include_router(followup.router, prefix="/api/v1/followup", tags=["Question"])
 app.include_router(
     memory_debug.router, prefix="/api/v1/memory-debug", tags=["Memory Debug"]
 )

--- a/apps/ai-server/app/models/followup.py
+++ b/apps/ai-server/app/models/followup.py
@@ -1,0 +1,69 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class FollowupRequest(BaseModel):
+    question_id: str = Field(..., description="부모 메인 질문 ID (예: q1)")
+    category: str = Field(..., description="behavioral|technical|tailored")
+    question_text: str = Field(..., description="부모 질문 본문")
+    criteria: List[str] = Field(
+        default_factory=list, description="평가 기준(부족한 부분을 파고듦)"
+    )
+    skills: List[str] = Field(default_factory=list, description="측정 역량 태그")
+    user_answer: str = Field(..., description="사용자 답변 전문")
+    evaluation_summary: Optional[str] = Field(
+        None, description="이전 평가 요약(강점/개선점/레드플래그 요약 텍스트)"
+    )
+    remaining_time_sec: Optional[int] = Field(None, description="남은 면접 시간(초)")
+    remaining_main_questions: Optional[int] = Field(
+        None, description="남은 메인 질문 수"
+    )
+    depth: int = Field(
+        1, ge=1, le=3, description="꼬리질문 추궁 강도(1=가벼움, 3=깊게)"
+    )
+    use_tailored_category: bool = Field(
+        False,
+        description="True면 꼬리질문 category를 항상 'tailored'로 간주하여 프롬프트에 전달",
+    )
+    auto_sequence: bool = Field(
+        True, description="True면 기존 꼬리질문 수를 기준으로 fu 번호 자동 증가"
+    )
+    next_followup_index: Optional[int] = Field(
+        None,
+        ge=1,
+        description="수동으로 fu 인덱스 지정(q3-fu{index}). auto_sequence=True면 무시",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "question_id": "q3",
+                "category": "technical",
+                "question_text": "Node.js와 Express로 API 성능을 어떻게 최적화했나요?",
+                "criteria": ["문제 해결", "성능 이해도", "재현 가능성"],
+                "skills": ["Node.js", "Express", "Redis"],
+                "user_answer": "API 성능 최적화를 위해 여러 가지 접근을 시도했습니다. 먼저 데이터베이스 쿼리를 분석해 불필요한 풀스캔을 없애고, 필요한 곳에 인덱스를 추가했습니다. 또한 Redis를 활용해 자주 조회되는 데이터를 캐싱하여 응답 속도를 크게 줄였습니다. 네트워크 측면에서는 gzip 압축과 HTTP/2를 적용해 전송 효율을 높였고, 서버 운영 환경에서는 PM2 클러스터 모드로 멀티코어를 활용하며 무중단 배포를 구현했습니다. 마지막으로 New Relic을 이용해 성능 지표를 실시간 모니터링하며, 병목 구간이 발견되면 즉시 개선 작업을 진행했습니다.",
+                "evaluation_summary": "강점: 방법 다양. 개선: 수치/검증 근거 부족.",
+                "remaining_time_sec": 820,
+                "remaining_main_questions": 4,
+                "depth": 2,
+                "use_tailored_category": True,
+            }
+        }
+    }
+
+
+class Followup(BaseModel):
+    followup_id: str = Field(..., description="꼬리질문 ID (예: q1-fu1)")
+    parent_question_id: str = Field(..., description="부모 메인 질문 ID")
+    focus_criteria: List[str] = Field(
+        default_factory=list, description="파고들 포커스 기준"
+    )
+    rationale: str = Field(..., description="생성 근거(한 줄)")
+    question_text: str = Field(..., alias="question", description="꼬리질문 본문")
+    expected_answer_time_sec: int = Field(
+        45, ge=15, le=180, description="예상 답변 시간(초)"
+    )
+
+    model_config = {"populate_by_name": True}

--- a/apps/ai-server/app/services/followup_generator.py
+++ b/apps/ai-server/app/services/followup_generator.py
@@ -1,0 +1,117 @@
+import json
+import os
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+from dotenv import load_dotenv
+from langchain.memory import ConversationBufferMemory
+from langchain.prompts import PromptTemplate
+from langchain_core.runnables import Runnable
+from langchain_openai import ChatOpenAI
+
+from app.models.followup import Followup, FollowupRequest
+from app.services.memory_logger import log_tail_question
+
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+PROMPT_PATH = (
+    Path(__file__).resolve().parent.parent / "config/prompt" / "followup_prompt.txt"
+).resolve()
+
+
+def _load_prompt_template(path: Path) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _strip_json(text: str) -> str:
+    m = re.search(r"```json(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    text = text.strip()
+    i, j = text.find("{"), text.rfind("}")
+    return text[i : j + 1] if i != -1 and j != -1 and j > i else text
+
+
+def _count_existing_followups(
+    memory: Optional[ConversationBufferMemory], parent_qid: str
+) -> int:
+    if memory is None:  # 메모리 미사용이면 0으로 간주
+        return 0
+    msgs = getattr(memory, "chat_memory", None)
+    if not msgs or not getattr(msgs, "messages", None):
+        return 0
+    cnt = 0
+    for m in msgs.messages:
+        content = str(getattr(m, "content", ""))
+        if (
+            '"parent_question_id"' in content
+            and f'"{parent_qid}"' in content
+            and '"followup_id"' in content
+        ):
+            cnt += 1
+    return cnt
+
+
+def generate_followups(
+    req: FollowupRequest, memory: Optional[ConversationBufferMemory] = None
+) -> Followup:
+    raw_prompt = _load_prompt_template(PROMPT_PATH)
+    prompt_template = PromptTemplate.from_template(raw_prompt)
+
+    llm = ChatOpenAI(openai_api_key=OPENAI_API_KEY, temperature=0.2, model="gpt-4o")
+    chain: Runnable = prompt_template | llm
+
+    category_for_prompt = "tailored" if req.use_tailored_category else req.category
+    vars: Dict[str, str | int | None] = {
+        "question_id": req.question_id,
+        "category": category_for_prompt,
+        "question_text": req.question_text,
+        "criteria_csv": ", ".join(req.criteria) if req.criteria else "",
+        "skills_csv": ", ".join(req.skills) if req.skills else "",
+        "user_answer": req.user_answer,
+        "evaluation_summary": req.evaluation_summary or "",
+        "remaining_time_sec": req.remaining_time_sec
+        if req.remaining_time_sec is not None
+        else "null",
+        "remaining_main_questions": req.remaining_main_questions
+        if req.remaining_main_questions is not None
+        else "null",
+        "depth": req.depth,
+    }
+
+    result = chain.invoke(vars)
+    content = result.content if hasattr(result, "content") else str(result)
+    json_text = _strip_json(content)
+
+    try:
+        parsed = json.loads(json_text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"LLM 꼬리질문 응답이 JSON 형식이 아닙니다: {e}")
+
+    if "question" not in parsed and "question_text" in parsed:
+        parsed["question"] = parsed["question_text"]
+
+    if req.auto_sequence:
+        existing = _count_existing_followups(memory, req.question_id)
+        idx = existing + 1
+    else:
+        idx = req.next_followup_index or 1
+
+    # 필수/기본값 보정
+    parsed.setdefault("parent_question_id", req.question_id)
+    parsed["followup_id"] = f"{req.question_id}-fu{idx}"
+    parsed.setdefault("focus_criteria", req.criteria or [])
+    parsed.setdefault("expected_answer_time_sec", 45)
+
+    # alias(question_text <-> question) 양쪽 허용
+    if "question_text" not in parsed and "question" in parsed:
+        parsed["question_text"] = parsed["question"]
+
+    followup = Followup.model_validate(parsed)
+    if memory is not None:
+        log_tail_question(memory, followup.model_dump())
+
+    return followup


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-60](https://konkuk-graduation-project.atlassian.net/browse/AIEW-60)
- **Branch**: feature/AIEW-60

---

### 작업 내용 📌

* 꼬리질문 생성 기능 구현
* 답변 평가 기반으로 후속 질문 1개 생성
* 꼬리질문 ID 자동 증가 및 세션 메모리 저장
* 프롬프트에 평가 요약, 잔여 시간/질문 수 반영
* Swagger 예시 요청/응답 추가

---

### 주요 변경 사항 ✍️

1. **apps/ai-server/app/services/followup\_generator.py**

   * `_strip_json` 함수 추가: LLM 응답에서 JSON 블록만 추출
   * `_count_existing_followups` 함수 추가: 메모리에서 동일 질문 ID 기준 fu 인덱스 자동 증가
   * `generate_followups` 함수 구현:

     * PromptTemplate을 통해 followup\_prompt.txt 로드
     * 평가 요약 및 시간 정보 포함하여 LLM 호출
     * 결과 파싱 후 필드 보정 및 Followup 모델로 검증
     * 세션 메모리에 저장 (log\_tail\_question 호출)

2. **apps/ai-server/app/models/followup.py**

   * `FollowupRequest` 모델 정의:

     * 메인 질문 ID, 평가 요약, 답변, 잔여 시간 등 포함
     * `use_tailored_category`, `depth`, `auto_sequence`, `next_followup_index`로 제어
   * `Followup` 응답 모델 정의:

     * `followup_id`, `question_text`, `expected_answer_time_sec`, `focus_criteria`, `rationale` 등 포함
   * Swagger 예시 JSON 스키마 제공

3. **apps/ai-server/app/api/v1/endpoints/followup.py**

   * `/followup-generating` API 엔드포인트 추가

     * 요청: FollowupRequest
     * 응답: Followup
     * 세션 메모리 의존성 주입 (Depends(MemoryDep))

4. **apps/ai-server/app/config/prompt/followup\_prompt.txt**

   * 프롬프트 지침 작성:

     * 기준: 평가 요약, 카테고리, 답변, 질문 내용
     * 제약: 중복/모호 금지, Yes/No 형태 금지, 코드/지표 요구, 짧은 시간 고려 등
     * 출력: JSON Only

5. **apps/ai-server/app/main.py**

   * `followup` 엔드포인트 FastAPI 라우터 등록

---

### 테스트 방법 🧑🏻‍🔬

* `pnpm dev` 실행 후 Swagger 또는 Postman으로 테스트

* 정상 요청

  * 조건: 모든 필드 입력, auto\_sequence = true
  * 기대 결과:

    * followup\_id가 `q3-fu1` 형식으로 생성됨
    * 예상 답변 시간, 포커스 기준, 질문 문장 포함
    * memory logger에 로그 저장됨
* 자동 인덱스 증가 확인

  * 같은 question\_id로 두 번 호출
  * 기대 결과: `q3-fu1`, `q3-fu2` 식으로 followup\_id 증가
* 수동 인덱스 지정

  * auto\_sequence = false, next\_followup\_index = 5
  * 기대 결과: followup\_id = `q3-fu5`
* 제한 조건 반영

  * remaining\_time\_sec = 30, remaining\_main\_questions = 1
  * 기대 결과: 질문 길이 짧아짐 또는 생성 생략
* use\_tailored\_category = true

  * 프롬프트에 category 값이 tailored로 강제됨

---

### 참고 사항 📂

* 꼬리질문 생성은 기존 평가 결과를 기반으로 하며 평가 기능 이후 단계로 연동됨
* followup\_id는 memory에 누적되어 인덱스 충돌 방지


[AIEW-60]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ