### PR TITLE
[AIEW-66] 쿠키 방식 사용자 인증 보완

### DIFF
--- a/apps/core-api/src/plugins/githubOAuth2.ts
+++ b/apps/core-api/src/plugins/githubOAuth2.ts
@@ -147,7 +147,7 @@ const githubOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
 
       // JWT를 쿠키에 담아 프론트엔드로 리디렉션
       reply
-        .setCookie('refresh_token', refreshToken, {
+        .setCookie('refreshToken', refreshToken, {
           path: '/',
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정

--- a/apps/core-api/src/plugins/githubOAuth2.ts
+++ b/apps/core-api/src/plugins/githubOAuth2.ts
@@ -152,6 +152,7 @@ const githubOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정
           sameSite: 'lax', // CSRF 공격 차단 + 정상적인 요청에서는 GET 허용
+          maxAge: 7 * 24 * 60 * 60, // 초 단위
         })
         .redirect(
           `http://localhost:4000/auth/callback?accessToken=${accessToken}`,

--- a/apps/core-api/src/plugins/googleOAuth2.ts
+++ b/apps/core-api/src/plugins/googleOAuth2.ts
@@ -129,7 +129,7 @@ const googleOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
 
       // JWT를 쿠키에 담아 프론트엔드로 리디렉션
       reply
-        .setCookie('refresh_token', refreshToken, {
+        .setCookie('refreshToken', refreshToken, {
           path: '/',
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정

--- a/apps/core-api/src/plugins/googleOAuth2.ts
+++ b/apps/core-api/src/plugins/googleOAuth2.ts
@@ -134,6 +134,7 @@ const googleOAuth2Plugin: FastifyPluginAsync = async (fastify) => {
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 true로 설정
           sameSite: 'lax', // CSRF 공격 차단 + 정상적인 요청에서는 GET 허용
+          maxAge: 7 * 24 * 60 * 60, // 초 단위
         })
         .redirect(
           `http://localhost:4000/auth/callback?accessToken=${accessToken}`,

--- a/apps/core-api/src/routes/api/v1/refresh/index.ts
+++ b/apps/core-api/src/routes/api/v1/refresh/index.ts
@@ -15,7 +15,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
   const postOpts: RouteShorthandOptions = {
     schema: {
       tags: [Tag.User],
-      summary: '쿠키 속 refresh_token으로 accessToken 재발급',
+      summary: '쿠키 속 refreshToken으로 accessToken 재발급',
       description:
         'HttpOnly, Secure 쿠키로 전달된 Refresh Token을 검증하여 새로운 Access Token을 발급합니다.<br/><br/>' +
         '**❗중요**: 이 API는 `HttpOnly` 쿠키를 사용하므로 Swagger UI의 "Try it out" 기능으로 직접 테스트할 수 없습니다.<br/>' +
@@ -25,7 +25,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
   const postHandler: RouteHandlerMethod = async (request, reply) => {
     try {
       // 1. 쿠키에서 리프레시 토큰 문자열을 직접 가져옵니다.
-      const refreshToken = request.cookies.refresh_token
+      const refreshToken = request.cookies.refreshToken
       if (!refreshToken) {
         return reply.status(401).send({ message: 'No refresh token provided' })
       }
@@ -39,7 +39,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       })
 
       if (!user) {
-        reply.clearCookie('refresh_token')
+        reply.clearCookie('refreshToken')
         return reply.status(401).send({ message: 'Unauthorized' })
       }
 
@@ -52,7 +52,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
     } catch (err) {
       // 토큰이 유효하지 않거나 만료된 경우
       fastify.log.error(err)
-      reply.clearCookie('refresh_token')
+      reply.clearCookie('refreshToken')
       return reply.status(401).send({ message: 'Unauthorized' })
     }
   }

--- a/apps/web-client/src/app/auth/callback/route.ts
+++ b/apps/web-client/src/app/auth/callback/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
       maxAge: 15 * 60, // 초 단위
+      sameSite: 'lax',
       path: '/', // 전체 경로에서 사용 가능
     })
   }

--- a/apps/web-client/src/app/auth/callback/route.ts
+++ b/apps/web-client/src/app/auth/callback/route.ts
@@ -9,6 +9,8 @@ export async function GET(request: Request) {
     cookieStore.set('accessToken', accessToken, {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
+      maxAge: 15 * 60, // 초 단위
+      path: '/', // 전체 경로에서 사용 가능
     })
   }
 

--- a/apps/web-client/src/middleware.ts
+++ b/apps/web-client/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function middleware(req: NextRequest) {
   const accessToken = req.cookies.get('accessToken')?.value
-  const refreshToken = req.cookies.get('refresh_token')?.value
+  const refreshToken = req.cookies.get('refreshToken')?.value
 
   // refresh token조차 없으면 무조건 로그인 페이지로
   if (!refreshToken) {

--- a/apps/web-client/src/middleware.ts
+++ b/apps/web-client/src/middleware.ts
@@ -1,35 +1,67 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function middleware(req: NextRequest) {
-  const access = req.cookies.get('accessToken')?.value
+  const accessToken = req.cookies.get('accessToken')?.value
+  const refreshToken = req.cookies.get('refresh_token')?.value
 
-  //accessToken이 없으면 refresh 요청
-  if (!access) {
-    const refreshRes = await fetch(`http://localhost:3000/api/v1/refresh`, {
-      method: 'POST',
-      headers: {
-        Cookie: req.headers.get('cookie') ?? '',
-      },
-    })
-
-    // refresh 성공 시 쿠키 설정
-    if (refreshRes.ok) {
-      const { accessToken } = await refreshRes.json()
-      const res = NextResponse.next()
-
-      res.cookies.set('accessToken', accessToken, {
-        httpOnly: true,
-        sameSite: 'lax',
-        path: '/',
-      })
-      return res
-    }
-
-    // refresh 실패 시 로그인 페이지로 리디렉션
+  // refresh token조차 없으면 무조건 로그인 페이지로
+  if (!refreshToken) {
     return NextResponse.redirect(new URL('/login', req.url))
   }
 
-  return NextResponse.next()
+  // access token이 없는 경우, 즉시 refresh 시도
+  if (!accessToken) {
+    return await tryRefresh(req)
+  }
+
+  // access token이 있는 경우, 유효성 검증
+  const meResponse = await fetch('http://localhost:3000/api/v1/me', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  // 토큰이 유효하면, 요청을 그대로 통과
+  if (meResponse.ok) {
+    return NextResponse.next()
+  }
+
+  // 토큰이 유효하지 않으면 refresh 시도
+  return await tryRefresh(req)
+}
+
+/**
+ * Refresh Token을 사용하여 새로운 Access Token을 발급받고,
+ * 성공 시 쿠키를 설정하여 다음 요청으로 넘기고,
+ * 실패 시 로그인 페이지로 리디렉션
+ */
+async function tryRefresh(req: NextRequest) {
+  const refreshRes = await fetch('http://localhost:3000/api/v1/refresh', {
+    method: 'POST',
+    headers: {
+      // 서버 사이드에서 fetch를 할 때는 브라우저가 아니므로 쿠키를 수동으로 담아줘야 함
+      Cookie: req.headers.get('cookie') ?? '',
+    },
+  })
+
+  // 리프레시 성공
+  if (refreshRes.ok) {
+    const { accessToken: newAccessToken } = await refreshRes.json()
+    // 다음 요청으로 보내기 위한 새로운 응답 객체를 생성합니다.
+    const response = NextResponse.next()
+    // 새로운 액세스 토큰을 쿠키에 설정합니다.
+    response.cookies.set('accessToken', newAccessToken, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 15 * 60,
+      sameSite: 'lax',
+      path: '/',
+    })
+    return response
+  }
+
+  // refresh 실패 (refresh token도 만료됨)
+  return NextResponse.redirect(new URL('/login', req.url))
 }
 
 //TODO: private 주소 한 파일로 변경해 관리하기 쉽도록 변경


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-66](https://konkuk-graduation-project.atlassian.net/browse/AIEW-66)
- **Branch**: feature/AIEW-66

---

### 문제 식별 👀 

- 백과 프론트에서 쿠키들에 maxAge가 설정되지 않아 `accessToken`과 `refreshToken`이 모두 세션 쿠키가 됨
- 로그인 후 15분이 지났을 때, 프론트에서 `/dashboard`에 접속하면 `refreshToken`을 통해 새로운 `accessToken`을 발급받아야 하지만 실패함
- 실제 검증에 사용되는 `accessToken`의 수명은 15분이지만 브라우저 종료 전까지 삭제되지 않는 세션 쿠키들로 인해 오류 발생
- 미들웨어에서는 렌더링을 허용했지만 실제로는 토큰이 만료된 상황

---

### 작업 내용 📌

- 쿠키에 maxAge 설정
- `middleware.ts`의 검증 로직 변경

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행
- [로그인 페이지](http://localhost:4000/login)에서 로그인
- 15분 후 개발자 도구에서 accessToken 쿠키가 없어졌는지 확인
- [대시보드](http://localhost:4000/dashboard)에 접속하여 refresh가 정상적으로 진행되는지 확인

---

### 참고 사항 📂

- 담당자의 확실한 검증이 필요 @lth-1026 
- 임의로 작성된 코드이니 확인 후 PR을 닫은 후 직접 작성하여도 되고, 해당 PR에 직접 수정 진행하여도 무방함


[AIEW-66]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ