### PR TITLE
[AIEW-70] 면접 세션 조회시 세부 직무 반환

### DIFF
--- a/apps/core-api/src/schemas/rest/interview.ts
+++ b/apps/core-api/src/schemas/rest/interview.ts
@@ -20,6 +20,11 @@ export const interviewSchema: ISchema = {
       description: '직무명',
       example: 'Software Engineer',
     },
+    jobSpec: {
+      type: 'string',
+      description: '세부 직무',
+      example: 'Backend Developer',
+    },
     currentQuestionIndex: {
       type: 'number',
       description: '현재 진행 중인 질문의 인덱스 (0부터 시작)',


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-70](https://konkuk-graduation-project.atlassian.net/browse/AIEW-70)
- **Branch**: feature/AIEW-70

---

### 작업 내용 📌

- 면접 리스트에서 세부 직무도 보여주기 위해 `jobSpec`을 `interviewSchema`에 추가

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행
- [Swagger](http://localhost:3000/docs#/%F0%9F%97%A3%EF%B8%8F%20%EB%A9%B4%EC%A0%91)에서 전체 & 단일 조회 실행

---

### 참고 사항 📂

- 이번처럼 프론트에서 필요한 정보가 생기면 DB에서 확인 후 요청주시면 스키마 바로 변경 가능
