### PR TITLE
[AIEW-73] 인터뷰 흐름 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Install python dependencies
         run: poetry --directory apps/ai-server install
 
+      - name: Start AI Server in Background
+        run: poetry run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+        working-directory: ./apps/ai-server
+
+      - name: Wait for AI Server to start
+        run: |
+          echo "Waiting 10 seconds for the AI server to be ready..."
+          sleep 10
+
       - name: Lint
         run: pnpm lint
 

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -47,6 +47,7 @@
     "concurrently": "^9.2.0",
     "fastify-tsconfig": "^3.0.0",
     "nodemon": "^3.1.10",
+    "socket.io-client": "^4.8.1",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.16",
     "tsc-watch": "^7.1.1",

--- a/apps/core-api/prisma/migrations/20250831072159_add_ai_question_id/migration.sql
+++ b/apps/core-api/prisma/migrations/20250831072159_add_ai_question_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `aiQuestionId` to the `InterviewStep` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "InterviewStep" ADD COLUMN     "aiQuestionId" TEXT NOT NULL;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -65,13 +65,14 @@ model InterviewSession {
 
 // 질문과 답변, 평가를 한 세트로 묶는 모델
 model InterviewStep {
-  id        String       @id @default(cuid())
-  type      QuestionType // 질문 유형 (기술, 인성, 맞춤)
-  question  String       // AI가 생성한 질문 내용
-  answer    String?      // 사용자의 답변 내용
-  score     Int?         // AI가 평가한 총점 (0-100)
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  aiQuestionId   String       // AI가 생성한 질문의 고유 ID
+  type           QuestionType // 질문 유형 (기술, 인성, 맞춤)
+  question       String       // AI가 생성한 질문 내용
+  answer         String?      // 사용자의 답변 내용
+  score          Int?         // AI가 평가한 총점 (0-100)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   // ++ 추가: 질문 생성 시의 메타데이터
   rationale              String?   // 질문 선정 근거

--- a/apps/core-api/src/plugins/services/interview.ts
+++ b/apps/core-api/src/plugins/services/interview.ts
@@ -1,6 +1,6 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { createId } from '@paralleldrive/cuid2'
-import { QuestionType } from '@prisma/client'
+import { InterviewStep, QuestionType } from '@prisma/client'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 
@@ -9,7 +9,12 @@ import { AiClientService } from './ai-client'
 import {
   AiInterviewQuestion,
   AiQuestionCategory,
+  AnswerEvaluationRequest,
+  EvaluationResult,
+  FollowUp,
+  FollowupRequest,
   QuestionGenerateResponse,
+  TailDecision,
 } from '@/types/ai.types'
 import { InterviewRequestBody } from '@/types/interview.types'
 
@@ -30,7 +35,7 @@ export class InterviewService {
   }
 
   /**
-   * 면접 세션을 초기화하고 즉시 sessionId를 반환합니다.
+   * 면접 세션을 초기화하고 즉시 session을 반환합니다.
    */
   public async initializeSession(
     userId: string,
@@ -38,9 +43,7 @@ export class InterviewService {
   ) {
     const { prisma, log } = this.fastify
     const sessionId = createId()
-
     log.info(`[${sessionId}] Initializing interview session...`)
-
     const session = await prisma.interviewSession.create({
       data: {
         id: sessionId,
@@ -51,7 +54,6 @@ export class InterviewService {
         idealTalent: interviewData.idealTalent.value,
       },
     })
-
     log.info(`[${sessionId}] Interview session initialized.`)
     return session
   }
@@ -67,78 +69,29 @@ export class InterviewService {
       portfolio: FilePayload
     },
   ) {
-    const { prisma, log, r2 } = this.fastify
-    const { R2_BUCKET_NAME, R2_PUBLIC_URL } = process.env
-
+    const { prisma, log } = this.fastify
     try {
       log.info(`[${sessionId}] Starting background processing...`)
-
-      const uploadPromises = Object.entries(files).map(async ([key, file]) => {
-        const fileKey = `${sessionId}-${key}-${file.filename}`
-        await r2.send(
-          new PutObjectCommand({
-            Bucket: R2_BUCKET_NAME,
-            Key: fileKey,
-            Body: file.buffer,
-            ContentType: 'application/pdf',
-          }),
-        )
-        return {
-          key: key as 'coverLetter' | 'portfolio',
-          url: `${R2_PUBLIC_URL}/${fileKey}`,
-        }
-      })
-      const fileUrlResults = await Promise.all(uploadPromises)
-      const fileUrls = fileUrlResults.reduce(
-        (acc, { key, url }) => {
-          acc[key] = url
-          return acc
-        },
-        {} as { coverLetter?: string; portfolio?: string },
-      )
+      const fileUrls = await this.uploadFilesToR2(sessionId, files)
       log.info(`[${sessionId}] Files uploaded successfully.`)
-
       await prisma.interviewSession.update({
         where: { id: sessionId },
-        data: {
-          coverLetter: fileUrls.coverLetter,
-          portfolio: fileUrls.portfolio,
-        },
+        data: fileUrls,
       })
-
-      log.info(`[${sessionId}] Parsing PDFs...`)
-      const [coverLetterParsed, portfolioParsed] = await Promise.all([
-        this.aiClient.parsePdf(
-          files.coverLetter.buffer,
-          files.coverLetter.filename,
-          sessionId,
-        ),
-        this.aiClient.parsePdf(
-          files.portfolio.buffer,
-          files.portfolio.filename,
-          sessionId,
-        ),
-      ])
+      const parsedTexts = await this.parsePdfFiles(sessionId, files)
       log.info(`[${sessionId}] PDFs parsed successfully.`)
-
-      const questionRequestData = {
-        user_info: {
-          resume_text: coverLetterParsed.extracted_text,
-          portfolio_text: portfolioParsed.extracted_text,
-          company: interviewData.company.value,
-          desired_role: interviewData.jobTitle.value,
-          core_values: interviewData.idealTalent.value,
-        },
-      }
+      const questionRequestData = this.prepareQuestionRequest(
+        interviewData,
+        parsedTexts,
+      )
       const generatedQuestions = await this.aiClient.generateQuestions(
         questionRequestData,
         sessionId,
       )
       log.info(`[${sessionId}] Questions generated successfully.`)
-
       await this.saveQuestionsAndNotifyClient(sessionId, generatedQuestions)
     } catch (error) {
-      log.error(`[${sessionId}] Error during background processing: ${error}`)
+      log.error(`[${sessionId}] Error during background processing:`, { error })
       this.fastify.io.to(sessionId).emit('server:error', {
         code: 'INTERVIEW_SETUP_FAILED',
         message: 'Failed to set up the interview. Please try again.',
@@ -153,40 +106,32 @@ export class InterviewService {
     const { prisma, log, io } = this.fastify
     try {
       log.info(`[${sessionId}] Formatting and saving questions to DB...`)
-
-      const typeMapping: Record<AiQuestionCategory, QuestionType> = {
-        [AiQuestionCategory.TECHNICAL]: QuestionType.TECHNICAL,
-        [AiQuestionCategory.BEHAVIORAL]: QuestionType.PERSONALITY,
-        [AiQuestionCategory.TAILORED]: QuestionType.TAILORED,
-      }
-
-      const stepsToCreate = questions.map((q: AiInterviewQuestion) => ({
-        interviewSessionId: sessionId,
-        type: typeMapping[q.category],
-        question: q.question,
-        criteria: q.criteria,
-        skills: q.skills,
-        rationale: q.rationale,
-      }))
-
+      const stepsToCreate = questions.map(this.formatQuestionToStep)
       if (stepsToCreate.length > 0) {
         await prisma.interviewStep.createMany({
-          data: stepsToCreate,
+          data: stepsToCreate.map((step) => ({
+            ...step,
+            interviewSessionId: sessionId,
+          })),
         })
       }
       log.info(`[${sessionId}] Questions saved successfully.`)
-
       const createdSteps = await prisma.interviewStep.findMany({
         where: { interviewSessionId: sessionId },
         orderBy: { createdAt: 'asc' },
       })
-
+      const firstQuestion = createdSteps[0]
+      await this.aiClient.logShownQuestion(
+        { question: this.formatStepToAiQuestion(firstQuestion) },
+        sessionId,
+      )
+      log.info(`[${sessionId}] Logged first question to AI memory.`)
       log.info(`[${sessionId}] Notifying client via WebSocket...`)
       io.to(sessionId).emit('server:questions-ready', { steps: createdSteps })
     } catch (error) {
-      log.error(
-        `[${sessionId}] Error in saveQuestionsAndNotifyClient: ${error}`,
-      )
+      log.error(`[${sessionId}] Error in saveQuestionsAndNotifyClient:`, {
+        error,
+      })
       io.to(sessionId).emit('server:error', {
         code: 'QUESTION_PROCESSING_FAILED',
         message: 'Failed to process and save interview questions.',
@@ -194,101 +139,286 @@ export class InterviewService {
     }
   }
 
-  /**
-   * 사용자의 답변을 처리하고 다음 질문을 반환하거나 면접을 종료합니다.
-   * TDD를 위해 우선 Mock 구현으로 시작합니다.
-   */
   public async processUserAnswer(
     sessionId: string,
     stepId: string,
     answer: string,
     duration: number,
   ) {
-    const { prisma, log } = this.fastify
+    const { prisma, log, io } = this.fastify
+    log.info(`[${sessionId}] Start processing answer for step ${stepId}...`)
+    try {
+      const currentStep = await prisma.interviewStep.update({
+        where: { id: stepId },
+        data: { answer, answerDurationSec: duration },
+      })
+      await this.aiClient.logUserAnswer(
+        {
+          question_id: currentStep.aiQuestionId,
+          answer: answer,
+          answer_duration_sec: duration,
+        },
+        sessionId,
+      )
+      const evaluationResult = await this.requestEvaluation(
+        currentStep,
+        answer,
+        duration,
+        sessionId,
+      )
+      await this.saveEvaluationResult(stepId, evaluationResult)
+      if (evaluationResult.tail_decision === TailDecision.CREATE) {
+        await this.handleFollowupQuestion(
+          sessionId,
+          currentStep,
+          answer,
+          evaluationResult,
+        )
+      } else {
+        await this.handleNextMainQuestion(sessionId)
+      }
+    } catch (error) {
+      log.error(`[${sessionId}] Error processing answer for step ${stepId}:`, {
+        error,
+      })
+      io.to(sessionId).emit('server:error', {
+        code: 'ANSWER_PROCESSING_FAILED',
+        message: 'Failed to process your answer.',
+      })
+    }
+    log.info(`[${sessionId}] Finished processing answer for step ${stepId}.`)
+  }
 
-    log.info(
-      `[${sessionId}] Processing answer for step ${stepId}: "${answer.substring(
-        0,
-        20,
-      )}..."`,
+  // --- Helper Methods ---
+  private async uploadFilesToR2(
+    sessionId: string,
+    files: { coverLetter: FilePayload; portfolio: FilePayload },
+  ) {
+    const { r2 } = this.fastify
+    const { R2_BUCKET_NAME, R2_PUBLIC_URL } = process.env
+    const uploadPromises = Object.entries(files).map(async ([key, file]) => {
+      const fileKey = `${sessionId}-${key}-${file.filename}`
+      await r2.send(
+        new PutObjectCommand({
+          Bucket: R2_BUCKET_NAME,
+          Key: fileKey,
+          Body: file.buffer,
+          ContentType: 'application/pdf',
+        }),
+      )
+      return {
+        key: key as 'coverLetter' | 'portfolio',
+        url: `${R2_PUBLIC_URL}/${fileKey}`,
+      }
+    })
+    const fileUrlResults = await Promise.all(uploadPromises)
+    return fileUrlResults.reduce(
+      (acc, { key, url }) => {
+        acc[key] = url
+        return acc
+      },
+      {} as { coverLetter?: string; portfolio?: string },
     )
+  }
 
-    // 답변 내용과 시간을 DB에 업데이트
-    await prisma.interviewStep.update({
+  private async parsePdfFiles(
+    sessionId: string,
+    files: { coverLetter: FilePayload; portfolio: FilePayload },
+  ) {
+    const [coverLetterParsed, portfolioParsed] = await Promise.all([
+      this.aiClient.parsePdf(
+        files.coverLetter.buffer,
+        files.coverLetter.filename,
+        sessionId,
+      ),
+      this.aiClient.parsePdf(
+        files.portfolio.buffer,
+        files.portfolio.filename,
+        sessionId,
+      ),
+    ])
+    return {
+      resume_text: coverLetterParsed.extracted_text,
+      portfolio_text: portfolioParsed.extracted_text,
+    }
+  }
+
+  private prepareQuestionRequest(
+    interviewData: InterviewRequestBody,
+    parsedTexts: { resume_text: string; portfolio_text: string },
+  ) {
+    return {
+      user_info: {
+        ...parsedTexts,
+        company: interviewData.company.value,
+        desired_role: interviewData.jobTitle.value,
+        core_values: interviewData.idealTalent.value,
+      },
+    }
+  }
+
+  private formatQuestionToStep(q: AiInterviewQuestion) {
+    const typeMapping: Record<AiQuestionCategory, QuestionType> = {
+      [AiQuestionCategory.TECHNICAL]: QuestionType.TECHNICAL,
+      [AiQuestionCategory.BEHAVIORAL]: QuestionType.PERSONALITY,
+      [AiQuestionCategory.TAILORED]: QuestionType.TAILORED,
+    }
+    return {
+      aiQuestionId: q.main_question_id,
+      type: typeMapping[q.category],
+      question: q.question,
+      criteria: q.criteria,
+      skills: q.skills,
+      rationale: q.rationale,
+      estimatedAnswerTimeSec: q.estimated_answer_time_sec,
+    }
+  }
+
+  private formatStepToAiQuestion(step: InterviewStep) {
+    return {
+      main_question_id: step.aiQuestionId,
+      category: step.type,
+      question_text: step.question,
+      criteria: step.criteria,
+      skills: step.skills,
+      rationale: step.rationale,
+      estimated_answer_time_sec: step.estimatedAnswerTimeSec,
+    }
+  }
+
+  private async requestEvaluation(
+    step: InterviewStep,
+    answer: string,
+    duration: number,
+    sessionId: string,
+  ) {
+    const request: AnswerEvaluationRequest = {
+      question_id: step.aiQuestionId,
+      category: step.type,
+      criteria: step.criteria,
+      skills: step.skills,
+      question_text: step.question,
+      user_answer: answer,
+      answer_duration_sec: duration,
+    }
+    return this.aiClient.evaluateAnswer(request, sessionId)
+  }
+
+  private async saveEvaluationResult(stepId: string, result: EvaluationResult) {
+    const { prisma } = this.fastify
+    return prisma.interviewStep.update({
       where: { id: stepId },
       data: {
-        answer: answer,
-        answerDurationSec: duration,
-      },
-    })
-
-    // 현재 세션 정보와 모든 질문 목록을 가져옴
-    const session = await prisma.interviewSession.findUnique({
-      where: { id: sessionId },
-      include: {
-        steps: {
-          orderBy: { createdAt: 'asc' },
+        score: result.overall_score,
+        strengths: result.strengths,
+        improvements: result.improvements,
+        redFlags: result.red_flags,
+        criterionEvaluations: {
+          createMany: {
+            data: result.criterion_scores.map((c) => ({
+              name: c.name,
+              score: c.score,
+              reason: c.reason,
+            })),
+          },
         },
       },
     })
+  }
 
-    if (!session) {
-      throw new Error('Interview session not found')
+  private async handleFollowupQuestion(
+    sessionId: string,
+    parentStep: InterviewStep,
+    answer: string,
+    evaluation: EvaluationResult,
+  ) {
+    const { prisma, log, io } = this.fastify
+    log.info(`[${sessionId}] Generating follow-up question...`)
+    const followupRequest: FollowupRequest = {
+      question_id: parentStep.aiQuestionId,
+      category: parentStep.type,
+      question_text: parentStep.question,
+      criteria: parentStep.criteria,
+      skills: parentStep.skills,
+      user_answer: answer,
+      evaluation_summary: `Strengths: ${evaluation.strengths.join(
+        ', ',
+      )}, Improvements: ${evaluation.improvements.join(', ')}`,
     }
-    const allSteps = session.steps
-
-    // --- AI 연동 로직 (현재는 Mock 처리) ---
-    // TODO: aiClientService.evaluateAndGetNextStep() 호출
-    const mockAiResponse = {
-      evaluation_result: {
-        /* ... */
+    const followupResult: FollowUp =
+      await this.aiClient.generateFollowUpQuestion(followupRequest, sessionId)
+    const createdFollowup = await prisma.interviewStep.create({
+      data: {
+        interviewSessionId: sessionId,
+        parentStepId: parentStep.id,
+        aiQuestionId: followupResult.followup_id,
+        type: parentStep.type,
+        question: followupResult.question,
+        criteria: followupResult.focus_criteria,
+        skills: parentStep.skills,
+        rationale: followupResult.rationale,
+        estimatedAnswerTimeSec: followupResult.expected_answer_time_sec,
       },
-      next_action: 'MAIN', // 항상 다음 메인 질문으로 간다고 가정
-      follow_up_question: null,
-    }
-    // TODO: 평가 결과 DB에 저장
-    // --- AI 연동 로직 끝 ---
+    })
 
-    const { next_action } = mockAiResponse
+    const newFollowupStep = await prisma.interviewStep.findUnique({
+      where: { id: createdFollowup.id },
+    })
 
-    if (next_action === 'FOLLOW_UP') {
-      // TODO: 꼬리 질문 처리 로직
+    if (!newFollowupStep) {
+      throw new Error('Failed to fetch newly created followup step.')
     }
 
-    if (next_action === 'MAIN') {
-      const mainQuestions = allSteps.filter((s) => !s.parentStepId)
+    await this.aiClient.logShownQuestion(
+      { question: this.formatStepToAiQuestion(newFollowupStep) },
+      sessionId,
+    )
+    log.info(`[${sessionId}] Next question logged to AI memory.`)
+    io.to(sessionId).emit('server:next-question', {
+      step: newFollowupStep,
+      isFollowUp: true,
+    })
+  }
 
-      // 현재가 마지막 메인 질문이었는지 확인
-      if (session.currentQuestionIndex >= mainQuestions.length - 1) {
-        log.info(
-          `[${sessionId}] Last main question answered. Finishing interview.`,
-        )
-        await prisma.interviewSession.update({
-          where: { id: sessionId },
-          data: { status: 'COMPLETED' },
-        })
-        return null // 면접 종료 신호
-      }
-
-      // 다음 메인 질문으로 넘기기
-      const nextIndex = session.currentQuestionIndex + 1
+  private async handleNextMainQuestion(sessionId: string) {
+    const { prisma, log, io } = this.fastify
+    const session = await prisma.interviewSession.findUnique({
+      where: { id: sessionId },
+      include: {
+        steps: { where: { parentStepId: null }, orderBy: { createdAt: 'asc' } },
+      },
+    })
+    if (!session) throw new Error(`Session not found for id: ${sessionId}`)
+    const mainQuestions = session.steps
+    const nextIndex = session.currentQuestionIndex + 1
+    if (nextIndex >= mainQuestions.length) {
+      log.info(
+        `[${sessionId}] Last main question answered. Finishing interview.`,
+      )
+      await prisma.interviewSession.update({
+        where: { id: sessionId },
+        data: { status: 'COMPLETED' },
+      })
+      io.to(sessionId).emit('server:interview-finished', { sessionId })
+    } else {
+      log.info(
+        `[${sessionId}] Moving to next main question index: ${nextIndex}`,
+      )
       await prisma.interviewSession.update({
         where: { id: sessionId },
         data: { currentQuestionIndex: nextIndex },
       })
-
-      log.info(
-        `[${sessionId}] Moving to next main question index: ${nextIndex}`,
+      const nextStep = mainQuestions[nextIndex]
+      await this.aiClient.logShownQuestion(
+        { question: this.formatStepToAiQuestion(nextStep) },
+        sessionId,
       )
-      return mainQuestions[nextIndex]
+      log.info(`[${sessionId}] Next question logged to AI memory.`)
+      io.to(sessionId).emit('server:next-question', {
+        step: nextStep,
+        isFollowUp: false,
+      })
     }
-
-    // 'END' 또는 예외 케이스
-    await prisma.interviewSession.update({
-      where: { id: sessionId },
-      data: { status: 'COMPLETED' },
-    })
-    return null
   }
 }
 
@@ -305,6 +435,6 @@ export default fp(
   },
   {
     name: 'interviewService',
-    dependencies: ['aiClientService', 'prisma', 'r2', 'io'],
+    dependencies: ['aiClientService', 'prisma', 'r2'],
   },
 )

--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -69,23 +69,12 @@ export default fp(
           duration: number
         }) => {
           try {
-            const nextStep = await fastify.interviewService.processUserAnswer(
+            await fastify.interviewService.processUserAnswer(
               sessionId,
               payload.stepId,
               payload.answer,
               payload.duration,
             )
-
-            if (nextStep) {
-              const isFollowUp = !!nextStep.parentStepId
-              fastify.io
-                .to(sessionId)
-                .emit('server:next-question', { step: nextStep, isFollowUp })
-            } else {
-              fastify.io
-                .to(sessionId)
-                .emit('server:interview-finished', { sessionId })
-            }
           } catch (error) {
             fastify.log.error(
               `[${sessionId}] Error processing answer for step ${payload.stepId}: ${error}`,
@@ -111,6 +100,8 @@ export default fp(
       instance.io.close()
       done()
     })
+
+    fastify.log.info('Socket.io plugin loaded')
   },
   {
     name: 'io',

--- a/apps/core-api/src/types/ai.types.ts
+++ b/apps/core-api/src/types/ai.types.ts
@@ -1,23 +1,176 @@
 /**
- * ai-server의 /question-generating 응답 모델에 대응하는 타입
+ * AI 서버가 생성하는 질문의 유형
  */
-
-// ai-server의 QuestionType Enum
 export enum AiQuestionCategory {
   BEHAVIORAL = 'behavioral', // 인성
   TECHNICAL = 'technical', // 기술
   TAILORED = 'tailored', // 맞춤
 }
 
-// ai-server의 InterviewQuestion 모델
+/**
+ * AI 서버의 /question-generating 엔드포인트 응답 객체 타입
+ */
 export interface AiInterviewQuestion {
   main_question_id: string
   category: AiQuestionCategory
   criteria: string[]
   skills: string[]
-  rationale: string | null
-  question: string // question_text가 question으로 alias 처리됨
-  estimated_answer_time_sec: number | null
+  rationale: string
+  question: string
+  estimated_answer_time_sec: number
 }
 
+/**
+ * AI 서버의 /question-generating 엔드포인트 전체 응답 타입
+ */
 export type QuestionGenerateResponse = AiInterviewQuestion[]
+
+/**
+ * AI 서버 /question-generating 요청의 user_info 필드 타입
+ */
+export interface AiUserInfo {
+  desired_role: string
+  company: string
+  core_values: string
+  resume_text: string
+  portfolio_text: string
+}
+
+/**
+ * AI 서버 /question-generating 요청의 constraints 필드 타입
+ */
+export interface AiQuestionConstraints {
+  language?: string
+  n?: number
+  timebox_total_sec?: number
+  avoid_question_ids?: string[]
+  seed?: number
+}
+
+/**
+ * AI 서버 /question-generating 엔드포인트 요청 본문 전체 타입
+ */
+export interface AiQuestionRequest {
+  user_info: AiUserInfo
+  constraints?: AiQuestionConstraints
+}
+
+// --- 답변 평가 및 꼬리 질문 관련 타입 ---
+
+/**
+ * AI 서버의 꼬리 질문 생성 여부 결정 타입
+ */
+export enum TailDecision {
+  CREATE = 'create',
+  SKIP = 'skip',
+}
+
+/**
+ * AI 서버의 세부 평가 기준 점수 객체 타입
+ */
+export interface CriterionScore {
+  name: string
+  score: number
+  reason: string
+}
+
+/**
+ * AI 서버의 /evaluate-answer 엔드포인트 응답 객체 타입
+ */
+export interface EvaluationResult {
+  question_id: string
+  category: string
+  answer_duration_sec: number
+  overall_score: number
+  strengths: string[]
+  improvements: string[]
+  red_flags: string[]
+  criterion_scores: CriterionScore[]
+  tail_decision: TailDecision
+  tail_rationale: string | null
+  tail_question: string | null
+}
+
+/**
+ * AI 서버의 /evaluate-answer 엔드포인트 요청 본문 타입
+ */
+export interface AnswerEvaluationRequest {
+  question_id: string
+  category: string
+  criteria: string[]
+  skills: string[]
+  question_text: string
+  user_answer: string
+  answer_duration_sec: number
+  remaining_time_sec?: number
+  remaining_main_questions?: number
+  use_tailored_category?: boolean
+}
+
+/**
+ * AI 서버가 생성하는 꼬리 질문 객체 타입
+ */
+export interface FollowUp {
+  followup_id: string
+  parent_question_id: string
+  focus_criteria: string[]
+  rationale: string
+  question: string
+  expected_answer_time_sec: number
+}
+
+/**
+ * AI 서버의 /followup-generating 엔드포인트 요청 본문 타입
+ */
+export interface FollowupRequest {
+  question_id: string
+  category: string
+  question_text: string
+  criteria: string[]
+  skills: string[]
+  user_answer: string
+  evaluation_summary?: string
+  remaining_time_sec?: number
+  remaining_main_questions?: number
+  depth?: number
+  use_tailored_category?: boolean
+  auto_sequence?: boolean
+  next_followup_index?: number
+}
+
+// --- AI 서버 메모리 로깅 관련 타입 ---
+
+/**
+ * AI 서버의 /log/question-shown 엔드포인트 요청 본문 타입
+ */
+export interface ShownQuestion {
+  question: {
+    [key: string]: unknown
+  }
+}
+
+/**
+ * AI 서버의 /log/user-answer 엔드포인트 요청 본문 타입
+ */
+export interface UserAnswer {
+  question_id: string
+  answer: string
+  answer_duration_sec: number
+}
+
+/**
+ * AI 서버의 /memory/dump 엔드포인트 응답의 메시지 객체 타입
+ */
+export interface MemoryMessage {
+  role: 'human' | 'ai' | 'system'
+  content: string
+}
+
+/**
+ * AI 서버의 /memory/dump 엔드포인트 응답 전체 타입
+ */
+export interface MemoryDump {
+  session_id: string
+  history_str: string
+  messages: MemoryMessage[]
+}

--- a/apps/core-api/test/helper.ts
+++ b/apps/core-api/test/helper.ts
@@ -1,34 +1,59 @@
 // This file contains code that we reuse between our tests.
+import { join } from 'node:path'
 import * as test from 'node:test'
-import { join } from 'path'
 
+import { S3Client } from '@aws-sdk/client-s3'
 import AutoLoad from '@fastify/autoload'
 import Cookie from '@fastify/cookie'
 import Cors from '@fastify/cors'
+import { FastifyJWT } from '@fastify/jwt'
 import Multipart from '@fastify/multipart'
 import { ajvFilePlugin } from '@fastify/multipart'
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
+import { PrismaClient, User } from '@prisma/client'
+import { FastifyInstance as OriginalFastifyInstance } from 'fastify'
 import Fastify from 'fastify'
+import { Server as SocketIOServer } from 'socket.io'
 
 import { app as AppPlugin } from '../src/app'
-// Manually import plugins to control loading order
-import jwtPlugin from '../src/plugins/jwt'
-import prismaPlugin from '../src/plugins/prisma'
-import sensiblePlugin from '../src/plugins/sensible'
-import socketIOPlugin from '../src/plugins/socket'
+import { AiClientService } from '../src/plugins/services/ai-client'
+import { InterviewService } from '../src/plugins/services/interview'
+
+// Extend the FastifyInstance interface with all our decorators
+declare module 'fastify' {
+  interface FastifyInstance {
+    prisma: PrismaClient
+    r2: S3Client
+    io: SocketIOServer
+    aiClientService: AiClientService
+    interviewService: InterviewService
+    authenticate(request: FastifyRequest, reply: FastifyReply): Promise<void>
+  }
+  // Add JWT decorator types
+  interface FastifyRequest {
+    jwt: FastifyJWT
+  }
+}
+
+// Use the extended interface
+export type FastifyInstance = OriginalFastifyInstance<
+  // eslint-disable-next-line
+  any,
+  // eslint-disable-next-line
+  any,
+  // eslint-disable-next-line
+  any,
+  // eslint-disable-next-line
+  any,
+  TypeBoxTypeProvider
+>
 
 export type TestContext = {
   after: typeof test.after
 }
 
-// Fill in this config with all the configurations
-// needed for testing the application
-function config() {
-  return {}
-}
-
 // Automatically build and tear down our instance
-async function build(t: TestContext) {
+async function build(t: TestContext): Promise<FastifyInstance> {
   const app = Fastify({
     ajv: {
       plugins: [ajvFilePlugin],
@@ -39,8 +64,7 @@ async function build(t: TestContext) {
   // Register the main application plugin first
   await app.register(AppPlugin)
 
-  // Register essential plugins manually in the correct order
-  await app.register(sensiblePlugin)
+  // Register essential plugins
   await app.register(Cookie)
   await app.register(Multipart, {
     attachFieldsToBody: true,
@@ -49,21 +73,22 @@ async function build(t: TestContext) {
     origin: 'http://localhost:4000',
     credentials: true,
   })
-  // Register plugins with dependencies
-  await app.register(prismaPlugin)
-  await app.register(jwtPlugin)
-  await app.register(socketIOPlugin)
 
-  // Load other plugins that don't have strict dependency order
+  // Autoload all plugins. fastify-plugin handles the dependency order.
   await app.register(AutoLoad, {
     dir: join(__dirname, '../src/plugins'),
-    ignorePattern: /prisma\.ts|jwt\.ts|sensible\.ts|socket\.ts/, // Ignore manually loaded plugins
+    options: {},
   })
 
-  // Load routes similar to server.ts
+  // Autoload all routes
   await app.register(AutoLoad, {
     dir: join(__dirname, '../src/routes'),
+    dirNameRoutePrefix: true,
+    options: {},
   })
+
+  // Start listening on an ephemeral port
+  await app.listen({ port: 0 })
 
   // Tear down our app after we are done
   t.after(() => app.close())
@@ -73,4 +98,23 @@ async function build(t: TestContext) {
   return app
 }
 
-export { config, build }
+/**
+ * Creates a test user in the database and returns the user and an access token.
+ */
+async function createTestUserAndToken(
+  app: FastifyInstance,
+): Promise<{ user: User; accessToken: string }> {
+  const testEmail = `test-${Date.now()}@example.com`
+  const user = await app.prisma.user.create({
+    data: {
+      email: testEmail,
+      name: 'Test User',
+      provider: 'TEST',
+    },
+  })
+
+  const accessToken = await app.jwt.sign({ userId: user.id })
+  return { user, accessToken }
+}
+
+export { build, createTestUserAndToken }

--- a/apps/core-api/test/helper.ts
+++ b/apps/core-api/test/helper.ts
@@ -58,7 +58,7 @@ async function build(t: TestContext): Promise<FastifyInstance> {
     ajv: {
       plugins: [ajvFilePlugin],
     },
-    logger: false, // Disable logger for cleaner test output
+    logger: true, // Disable logger for cleaner test output
   }).withTypeProvider<TypeBoxTypeProvider>()
 
   // Register the main application plugin first

--- a/apps/core-api/test/routes/ws/interview.test.ts
+++ b/apps/core-api/test/routes/ws/interview.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+import { InterviewStep } from '@prisma/client'
+import { FastifyInstance } from 'fastify'
+import { io as Client, Socket as ClientSocket } from 'socket.io-client'
+
+import { build, createTestUserAndToken } from '../../helper'
+
+import { QuestionGenerateResponse, AiQuestionCategory } from '@/types/ai.types'
+
+const mockGeneratedQuestions: QuestionGenerateResponse = [
+  {
+    main_question_id: '1',
+    category: AiQuestionCategory.TECHNICAL,
+    question: 'What is the difference between TCP and UDP?',
+    criteria: ['Protocol characteristics', 'Use cases'],
+    skills: ['Networking'],
+    rationale: 'Fundamental networking knowledge is essential.',
+    estimated_answer_time_sec: 60,
+  },
+  {
+    main_question_id: '2',
+    category: AiQuestionCategory.BEHAVIORAL,
+    question: 'Tell me about a time you had a conflict with a coworker.',
+    criteria: ['Conflict resolution', 'Communication'],
+    skills: ['Teamwork', 'Communication'],
+    rationale: 'Assesses interpersonal skills.',
+    estimated_answer_time_sec: 40,
+  },
+]
+
+test('WebSocket interview flow - happy path', async (t) => {
+  const app: FastifyInstance = await build(t)
+  const addressInfo = app.server.address()
+  if (addressInfo === null || typeof addressInfo === 'string') {
+    throw new Error('Server address is not available')
+  }
+  const address = `http://localhost:${addressInfo.port}`
+
+  // 서비스 레이어를 통해 테스트 유저와 세션을 생성
+  const { user } = await createTestUserAndToken(app)
+
+  // 테스트 종료 후 유저를 삭제하기 위한 훅 추가
+  t.after(async () => {
+    await app.prisma.user.delete({ where: { id: user.id } })
+  })
+
+  const session = await app.interviewService.initializeSession(user.id, {
+    company: { value: 'TestCorp' },
+    jobTitle: { value: 'Software Engineer' },
+    jobSpec: { value: 'Develop amazing things' },
+    idealTalent: { value: 'Proactive and collaborative' },
+  })
+  const sessionId = session.id
+
+  // 웹소켓 클라이언트 생성
+  const client: ClientSocket = Client(address, {
+    query: { sessionId },
+    autoConnect: false,
+  })
+
+  // 이벤트와 연결을 기다리기 위한 Promise 세팅
+  const questionsReadyPromise = new Promise<{ steps: InterviewStep[] }>(
+    (resolve, reject) => {
+      client.on('server:questions-ready', resolve)
+      client.on('server:error', reject)
+      client.on('connect_error', reject)
+    },
+  )
+
+  const connectionPromise = new Promise<void>((resolve) => {
+    client.on('connect', resolve)
+  })
+
+  // 연결 요청하고 기다리기
+  client.connect()
+  await connectionPromise
+
+  // 연결되었을테니 서버로부터 이벤트 트리거
+  await app.interviewService.saveQuestionsAndNotifyClient(
+    sessionId,
+    mockGeneratedQuestions,
+  )
+
+  // 'server:questions-ready'를 기다리기
+  const questionsReadyPayload = await questionsReadyPromise
+  const steps = questionsReadyPayload.steps
+  assert.ok(Array.isArray(steps) && steps.length > 0, 'Should receive steps')
+  const firstStepId = steps[0].id
+
+  // 사용자의 답변을 submit 하고 다음 질문 기다리기
+  const nextQuestionPromise = new Promise<{
+    step: InterviewStep
+    isFollowUp: boolean
+  }>((resolve) => {
+    client.on('server:next-question', resolve)
+  })
+
+  client.emit('client:submit-answer', {
+    stepId: firstStepId,
+    answer: 'This is my test answer for the first question.',
+    duration: 42,
+  })
+
+  const nextQuestionPayload = await nextQuestionPromise
+
+  // 응답 assert
+  assert.ok(
+    nextQuestionPayload,
+    'Should receive a payload for the next question',
+  )
+  assert.strictEqual(
+    typeof nextQuestionPayload.step.id,
+    'string',
+    'Next step ID should be a string',
+  )
+  assert.notStrictEqual(
+    nextQuestionPayload.step.id,
+    firstStepId,
+    'Next step ID should be different from the first step ID',
+  )
+  assert.strictEqual(
+    nextQuestionPayload.isFollowUp,
+    false,
+    'isFollowUp should be false for the next main question',
+  )
+  assert.strictEqual(
+    nextQuestionPayload.step.question,
+    mockGeneratedQuestions[1].question,
+    'Should receive the second question',
+  )
+
+  // 연결 해제
+  client.disconnect()
+})

--- a/apps/core-api/test/routes/ws/interview.test.ts
+++ b/apps/core-api/test/routes/ws/interview.test.ts
@@ -1,17 +1,26 @@
 import assert from 'node:assert'
+import http from 'node:http'
 import { test } from 'node:test'
 
 import { InterviewStep } from '@prisma/client'
+import axios from 'axios'
 import { FastifyInstance } from 'fastify'
 import { io as Client, Socket as ClientSocket } from 'socket.io-client'
 
 import { build, createTestUserAndToken } from '../../helper'
 
-import { QuestionGenerateResponse, AiQuestionCategory } from '@/types/ai.types'
+import {
+  QuestionGenerateResponse,
+  AiQuestionCategory,
+  EvaluationResult,
+  TailDecision,
+  FollowUp,
+  MemoryDump,
+} from '@/types/ai.types'
 
 const mockGeneratedQuestions: QuestionGenerateResponse = [
   {
-    main_question_id: '1',
+    main_question_id: 'q1',
     category: AiQuestionCategory.TECHNICAL,
     question: 'What is the difference between TCP and UDP?',
     criteria: ['Protocol characteristics', 'Use cases'],
@@ -20,7 +29,7 @@ const mockGeneratedQuestions: QuestionGenerateResponse = [
     estimated_answer_time_sec: 60,
   },
   {
-    main_question_id: '2',
+    main_question_id: 'q2',
     category: AiQuestionCategory.BEHAVIORAL,
     question: 'Tell me about a time you had a conflict with a coworker.',
     criteria: ['Conflict resolution', 'Communication'],
@@ -30,23 +39,76 @@ const mockGeneratedQuestions: QuestionGenerateResponse = [
   },
 ]
 
-test('WebSocket interview flow - happy path', async (t) => {
+// Create an agent that does not use keep-alive connections.
+// This is crucial for allowing the test process to exit gracefully.
+const httpAgent = new http.Agent({ keepAlive: false })
+
+/**
+ * Mocks methods of the aiClientService whose RETURN VALUES are needed to control logic flow.
+ * Methods that are "fire-and-forget" (like logging) are NOT mocked,
+ * allowing us to verify their side effects (i.e., memory updates).
+ * @param app The Fastify instance.
+ * @param t The test context.
+ * @param evaluationResult A partial EvaluationResult to override defaults.
+ */
+const mockAiClient = (
+  app: FastifyInstance,
+  t: test.TestContext,
+  evaluationResult: Partial<EvaluationResult>,
+) => {
+  const originalEvaluateAnswer = app.aiClientService.evaluateAnswer
+  const originalGenerateFollowUp = app.aiClientService.generateFollowUpQuestion
+
+  t.after(() => {
+    app.aiClientService.evaluateAnswer = originalEvaluateAnswer
+    app.aiClientService.generateFollowUpQuestion = originalGenerateFollowUp
+  })
+
+  app.aiClientService.evaluateAnswer = async (): Promise<EvaluationResult> => {
+    return {
+      question_id: 'q1',
+      category: AiQuestionCategory.BEHAVIORAL,
+      overall_score: 80,
+      strengths: ['Clear explanation'],
+      improvements: ['Could be more detailed'],
+      red_flags: [],
+      criterion_scores: [],
+      tail_decision: TailDecision.SKIP,
+      tail_rationale: 'Answer was sufficient.',
+      tail_question: null,
+      ...evaluationResult,
+    } as EvaluationResult
+  }
+
+  app.aiClientService.generateFollowUpQuestion =
+    async (): Promise<FollowUp> => {
+      return {
+        followup_id: 'q1-fu1',
+        parent_question_id: 'q1',
+        focus_criteria: ['Protocol characteristics'],
+        rationale: 'To delve deeper into the technical understanding.',
+        question: 'Can you elaborate on the handshake process in TCP?',
+        expected_answer_time_sec: 75,
+      }
+    }
+}
+
+test('WebSocket interview flow - happy path (generates follow-up and updates memory)', async (t) => {
   const app: FastifyInstance = await build(t)
+  mockAiClient(app, t, { tail_decision: TailDecision.CREATE })
+
   const addressInfo = app.server.address()
   if (addressInfo === null || typeof addressInfo === 'string') {
     throw new Error('Server address is not available')
   }
   const address = `http://localhost:${addressInfo.port}`
-  console.log(`[TEST] Server listening on ${address}`)
 
   // 서비스 레이어를 통해 테스트 유저와 세션을 생성
   const { user } = await createTestUserAndToken(app)
-  console.log(`[TEST] Created user: ${user.id}`)
 
   // 테스트 종료 후 유저를 삭제하기 위한 훅 추가
   t.after(async () => {
     await app.prisma.user.delete({ where: { id: user.id } })
-    console.log(`[TEST] Cleaned up user: ${user.id}`)
   })
 
   const session = await app.interviewService.initializeSession(user.id, {
@@ -56,107 +118,234 @@ test('WebSocket interview flow - happy path', async (t) => {
     idealTalent: { value: 'Proactive and collaborative' },
   })
   const sessionId = session.id
-  console.log(`[TEST] Initialized session: ${sessionId}`)
 
-  // 웹소켓 클라이언트 생성
+  // Reset AI server memory for this session to ensure a clean slate
+  await axios.delete(`${process.env.AI_SERVER_URL}/api/v1/memory-debug/reset`, {
+    headers: { 'X-Session-Id': sessionId },
+    httpAgent,
+  })
+
   const client: ClientSocket = Client(address, {
     query: { sessionId },
     autoConnect: false,
   })
 
-  // Log all events received from the server
-  client.onAny((eventName, ...args) => {
-    console.log(`[TEST CLIENT] Received event: ${eventName}`, ...args)
-  })
-
-  // 이벤트와 연결을 기다리기 위한 Promise 세팅
   const questionsReadyPromise = new Promise<{ steps: InterviewStep[] }>(
     (resolve, reject) => {
       client.on('server:questions-ready', resolve)
       client.on('server:error', reject)
-      client.on('connect_error', reject)
     },
   )
 
-  const connectionPromise = new Promise<void>((resolve) => {
-    client.on('connect', () => {
-      console.log('[TEST CLIENT] Connected to server.')
-      resolve()
-    })
-  })
-
-  // 연결 요청하고 기다리기
-  console.log('[TEST CLIENT] Connecting...')
+  const connectionPromise = new Promise<void>((resolve) =>
+    client.on('connect', resolve),
+  )
   client.connect()
   await connectionPromise
 
-  // 연결되었을테니 서버로부터 이벤트 트리거
-  console.log('[TEST] Triggering saveQuestionsAndNotifyClient...')
   await app.interviewService.saveQuestionsAndNotifyClient(
     sessionId,
     mockGeneratedQuestions,
   )
 
-  // 'server:questions-ready'를 기다리기
-  console.log('[TEST] Waiting for server:questions-ready...')
-  const questionsReadyPayload = await questionsReadyPromise
-  const steps = questionsReadyPayload.steps
-  assert.ok(Array.isArray(steps) && steps.length > 0, 'Should receive steps')
+  const { steps } = await questionsReadyPromise
   const firstStepId = steps[0].id
-  console.log(
-    `[TEST] Received ${steps.length} questions. First step ID: ${firstStepId}`,
-  )
+  const userAnswer = 'This is my test answer for the first question.'
 
-  // 사용자의 답변을 submit 하고 다음 질문 기다리기
   const nextQuestionPromise = new Promise<{
     step: InterviewStep
     isFollowUp: boolean
   }>((resolve, reject) => {
     client.on('server:next-question', resolve)
-    client.on('server:error', reject) // Also listen for errors here
+    client.on('server:error', reject)
   })
 
-  console.log(
-    `[TEST CLIENT] Emitting client:submit-answer for step ${firstStepId}...`,
-  )
   client.emit('client:submit-answer', {
     stepId: firstStepId,
-    answer: 'This is my test answer for the first question.',
+    answer: userAnswer,
     duration: 42,
   })
 
-  console.log('[TEST] Waiting for server:next-question...')
   const nextQuestionPayload = await nextQuestionPromise
 
-  // 응답 assert
-  console.log('[TEST] Asserting the response...')
-  assert.ok(
-    nextQuestionPayload,
-    'Should receive a payload for the next question',
+  assert.ok(nextQuestionPayload)
+  assert.strictEqual(nextQuestionPayload.isFollowUp, true)
+  assert.strictEqual(nextQuestionPayload.step.parentStepId, firstStepId)
+  assert.strictEqual(nextQuestionPayload.step.aiQuestionId, 'q1-fu1')
+
+  // Verify AI server memory
+  const memoryResponse = await axios.get<MemoryDump>(
+    `${process.env.AI_SERVER_URL}/api/v1/memory-debug/dump`,
+    { headers: { 'X-Session-Id': sessionId }, httpAgent },
   )
+
+  const memoryDump = memoryResponse.data
+  const aiMessages = memoryDump.messages.filter((m) => m.role === 'ai')
+
+  assert.strictEqual(memoryDump.session_id, sessionId)
+  assert.strictEqual(aiMessages.length, 3) // 1. question-shown, 2. user-answer, 3. followup-shown
+
+  const firstAiMsgContent = JSON.parse(aiMessages[0].content)
   assert.strictEqual(
-    typeof nextQuestionPayload.step.id,
-    'string',
-    'Next step ID should be a string',
+    firstAiMsgContent.main_question_id,
+    mockGeneratedQuestions[0].main_question_id,
   )
-  assert.notStrictEqual(
-    nextQuestionPayload.step.id,
-    firstStepId,
-    'Next step ID should be different from the first step ID',
+
+  const humanMsgContent = JSON.parse(aiMessages[1].content)
+  assert.strictEqual(humanMsgContent.answer, userAnswer)
+
+  const secondAiMsgContent = JSON.parse(aiMessages[2].content)
+  assert.strictEqual(secondAiMsgContent.main_question_id, 'q1-fu1')
+
+  client.disconnect()
+})
+
+test('WebSocket interview flow - skips follow-up', async (t) => {
+  const app: FastifyInstance = await build(t)
+  mockAiClient(app, t, { tail_decision: TailDecision.SKIP })
+
+  const addressInfo = app.server.address()
+  if (addressInfo === null || typeof addressInfo === 'string') {
+    throw new Error('Server address is not available')
+  }
+  const address = `http://localhost:${addressInfo.port}`
+
+  const { user } = await createTestUserAndToken(app)
+  t.after(async () => {
+    await app.prisma.user.delete({ where: { id: user.id } })
+  })
+
+  const session = await app.interviewService.initializeSession(user.id, {
+    company: { value: 'TestCorp' },
+    jobTitle: { value: 'Software Engineer' },
+    jobSpec: { value: 'Develop amazing things' },
+    idealTalent: { value: 'Proactive and collaborative' },
+  })
+  const sessionId = session.id
+
+  const client: ClientSocket = Client(address, {
+    query: { sessionId },
+    autoConnect: false,
+  })
+
+  const questionsReadyPromise = new Promise<{ steps: InterviewStep[] }>(
+    (resolve) => client.on('server:questions-ready', resolve),
   )
-  assert.strictEqual(
-    nextQuestionPayload.isFollowUp,
-    false,
-    'isFollowUp should be false for the next main question',
+  const connectionPromise = new Promise<void>((resolve) =>
+    client.on('connect', resolve),
   )
+
+  client.connect()
+  await connectionPromise
+
+  await app.interviewService.saveQuestionsAndNotifyClient(
+    sessionId,
+    mockGeneratedQuestions,
+  )
+
+  const { steps } = await questionsReadyPromise
+  const firstStepId = steps[0].id
+
+  const nextQuestionPromise = new Promise<{
+    step: InterviewStep
+    isFollowUp: boolean
+  }>((resolve) => client.on('server:next-question', resolve))
+
+  client.emit('client:submit-answer', {
+    stepId: firstStepId,
+    answer: 'A very good answer that does not need a follow-up.',
+    duration: 30,
+  })
+
+  const nextQuestionPayload = await nextQuestionPromise
+
+  assert.strictEqual(nextQuestionPayload.isFollowUp, false)
   assert.strictEqual(
     nextQuestionPayload.step.question,
     mockGeneratedQuestions[1].question,
-    'Should receive the second question',
   )
-  console.log('[TEST] Assertions passed.')
+  assert.strictEqual(nextQuestionPayload.step.id, steps[1].id)
 
-  // 연결 해제
-  console.log('[TEST CLIENT] Disconnecting...')
+  client.disconnect()
+})
+
+test('WebSocket interview flow - finishes interview', async (t) => {
+  const app: FastifyInstance = await build(t)
+  mockAiClient(app, t, { tail_decision: TailDecision.SKIP })
+
+  const addressInfo = app.server.address()
+  if (addressInfo === null || typeof addressInfo === 'string') {
+    throw new Error('Server address is not available')
+  }
+  const address = `http://localhost:${addressInfo.port}`
+
+  const { user } = await createTestUserAndToken(app)
+  t.after(async () => {
+    await app.prisma.user.delete({ where: { id: user.id } })
+  })
+
+  const session = await app.interviewService.initializeSession(user.id, {
+    company: { value: 'TestCorp' },
+    jobTitle: { value: 'Software Engineer' },
+    jobSpec: { value: 'Develop amazing things' },
+    idealTalent: { value: 'Proactive and collaborative' },
+  })
+  const sessionId = session.id
+
+  const client: ClientSocket = Client(address, {
+    query: { sessionId },
+    autoConnect: false,
+  })
+
+  const questionsReadyPromise = new Promise<{ steps: InterviewStep[] }>(
+    (resolve) => client.on('server:questions-ready', resolve),
+  )
+  const connectionPromise = new Promise<void>((resolve) =>
+    client.on('connect', resolve),
+  )
+
+  client.connect()
+  await connectionPromise
+
+  await app.interviewService.saveQuestionsAndNotifyClient(
+    sessionId,
+    mockGeneratedQuestions,
+  )
+
+  const { steps } = await questionsReadyPromise
+  const firstStepId = steps[0].id
+  const secondStepId = steps[1].id
+
+  const nextQuestionPromise = new Promise<{
+    step: InterviewStep
+    isFollowUp: boolean
+  }>((resolve) => client.on('server:next-question', resolve))
+
+  client.emit('client:submit-answer', {
+    stepId: firstStepId,
+    answer: 'A very good answer that does not need a follow-up.',
+    duration: 30,
+  })
+  await nextQuestionPromise
+
+  const interviewFinishedPromise = new Promise<{ sessionId: string }>(
+    (resolve) => client.on('server:interview-finished', resolve),
+  )
+
+  client.emit('client:submit-answer', {
+    stepId: secondStepId,
+    answer: 'This is the final answer.',
+    duration: 35,
+  })
+
+  const finishedPayload = await interviewFinishedPromise
+
+  assert.strictEqual(finishedPayload.sessionId, sessionId)
+
+  const finalSession = await app.prisma.interviewSession.findUnique({
+    where: { id: sessionId },
+  })
+  assert.strictEqual(finalSession?.status, 'COMPLETED')
+
   client.disconnect()
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       nodemon:
         specifier: ^3.1.10
         version: 3.1.10
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.16.5)(typescript@5.8.3)


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-73](https://konkuk-graduation-project.atlassian.net/browse/AIEW-73)
- **Branch**: feature/AIEW-73

---

### 작업 내용 📌

- 화면 완성되기 전이므로 개발 편의를 위해 TDD 적용
- 3개의 테스트 케이스 코드 완성 후 실제 동작하도록 구현
  1. 사용자가 첫 번째 질문에 답변했을 때, AI가 답변이 더 파고들 가치가 있다고 판단하여 꼬리 질문을 생성하는 상황
  2. 사용자의 답변이 충분히 명확하여, AI가 꼬리 질문 없이 다음 메인 질문으로 넘어가기로 결정하는 상황
  3. 사용자가 마지막 메인 질문에 답변하고, AI가 꼬리 질문을 만들지 않기로 결정하여 면접이 정상적으로 종료되는 상황
- 서비스 레이어는 2개
  1. `aiClientService`
      - `ai-server`와 통신을 전부 담당
  2. `interviewService`
      - 세션 생성 작업 관련 내용은 #43 에서
      - 사용자가 웹소켓을 통해 답변을 제출하면 `processUserAnswer` 함수가 호출되어, 실시간 상호작용을 처리

---

### 주요 변경 사항 ✍️

- `processUserAnswer`:
  1. 답변 기록: 사용자의 답변 내용과 답변 시간을 DB에 업데이트하고, AI의 대화 기록에도 로깅 (`logUserAnswer`).
  2. AI에게 평가 요청: `aiClientService.evaluateAnswer`를 호출하여, AI에게 답변을 평가하고 다음 행동(`tail_decision`) 결정 요청
  3. 평가 결과 저장: AI가 보내준 점수, 강점, 개선점 등을 DB에 저장
  4. 다음 행동 분기:
      - 꼬리 질문 생성 (`handleFollowupQuestion`): AI가 'create'를 결정하면, `aiClientService.generateFollowUpQuestion`을 호출하여 꼬리 질문을 받아온 뒤, DB에 새로 저장하고 클라이언트에 전송
      - 다음 질문 이동 (`handleNextMainQuestion`): AI가 'skip'을 결정하면, 다음 순서의 메인 질문을 클라이언트에게 보내거나, 마지막 질문이면 면접 종료 이벤트를 보냄

---

### 테스트 방법 🧑🏻‍🔬

- ` poetry --directory apps/ai-server run uvicorn app.main:app --reload --port 8000` 실행
  - 정확한 원인은 모르겠으나 `core-api`의 개발 서버가 실행 중이면 일부 테스트가 종료되지 않음
- `pnpm test` 실행

---

### 참고 사항 📂

- ai-server에서 질문에 id를 붙이는 방식이 고정되어있어 DB 스키마 변경했으니 참고
- 관련 내용 문서화는 추후 진행 예정


[AIEW-73]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ