### PR TITLE
[AIEW-85] 면접 세션 상태 관리 및 조회 기능 구현

### DIFF
--- a/apps/core-api/prisma/migrations/20250902052957_add_session_status_and_title/migration.sql
+++ b/apps/core-api/prisma/migrations/20250902052957_add_session_status_and_title/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The `status` column on the `InterviewSession` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - A unique constraint covering the columns `[userId,title]` on the table `InterviewSession` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `title` to the `InterviewSession` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "InterviewSessionStatus" AS ENUM ('PENDING', 'READY', 'IN_PROGRESS', 'COMPLETED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "InterviewSession" ADD COLUMN     "title" TEXT NOT NULL,
+DROP COLUMN "status",
+ADD COLUMN     "status" "InterviewSessionStatus" NOT NULL DEFAULT 'PENDING';
+
+-- DropEnum
+DROP TYPE "InterviewStatus";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InterviewSession_userId_title_key" ON "InterviewSession"("userId", "title");

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -20,11 +20,13 @@ enum QuestionType {
   TAILORED
 }
 
-// ++ 추가: 면접 세션의 진행 상태를 나타내는 Enum
-enum InterviewStatus {
-  NOT_STARTED // 생성만 되고 아직 시작 안 함
-  IN_PROGRESS // 진행 중
-  COMPLETED   // 모든 질문에 답변 완료
+// 면접 세션의 진행 상태를 나타내는 Enum
+enum InterviewSessionStatus {
+  PENDING     // AI 질문 생성 중
+  READY       // 면접 시작 가능
+  IN_PROGRESS // 면접 진행 중
+  COMPLETED   // 면접 완료
+  FAILED      // AI 질문 생성 실패
 }
 
 model User {
@@ -42,6 +44,7 @@ model User {
 
 model InterviewSession {
   id                   String   @id @default(cuid())
+  title                String   // 예: "토스뱅크 interview 1"
   company              String
   jobTitle             String
   jobSpec              String
@@ -53,14 +56,15 @@ model InterviewSession {
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 
-  // ++ 추가: 면접 진행 상태 및 전체 시간
-  status               InterviewStatus @default(NOT_STARTED)
+  status               InterviewSessionStatus @default(PENDING)
   totalTimeSec         Int?            // 면접 전체 제한 시간 (초)
 
   // Relations
   user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId  String
   steps   InterviewStep[] // 이 세션에 속한 모든 질문/답변 목록
+
+  @@unique([userId, title])
 }
 
 // 질문과 답변, 평가를 한 세트로 묶는 모델

--- a/apps/core-api/src/routes/api/v1/interviews/index.ts
+++ b/apps/core-api/src/routes/api/v1/interviews/index.ts
@@ -1,43 +1,33 @@
-import {
-  FastifyPluginAsync,
-  RouteHandler,
-  RouteShorthandOptions,
-} from 'fastify'
+import { FastifyPluginAsync, FastifySchema, RouteHandler } from 'fastify'
 
 import { Tag } from '@/configs/swaggerOption'
 import SchemaId from '@/utils/schemaId'
 
-const route: FastifyPluginAsync = async (fastify) => {
-  const routePath: string = '/'
-  const opts: RouteShorthandOptions = {
-    onRequest: [fastify.authenticate],
-    schema: {
-      tags: [Tag.Interview],
-      summary: '사용자가 생성한 모든 면접 세션 목록 조회',
-      description: '사용자가 생성한 면접 세션들의 목록을 반환합니다.',
-      response: {
-        '200': {
-          type: 'array',
-          items: {
-            $ref: SchemaId.Interview,
-          },
-        },
+const controller: FastifyPluginAsync = async (fastify) => {
+  const schema: FastifySchema = {
+    tags: [Tag.Interview],
+    summary: '사용자가 생성한 모든 면접 세션 목록 조회',
+    description: '사용자가 생성한 면접 세션들의 목록을 반환합니다.',
+    response: {
+      '200': {
+        $ref: SchemaId.InterviewList,
       },
     },
   }
+
   const handler: RouteHandler = async (request, reply) => {
-    const sessions = await fastify.prisma.interviewSession.findMany({
-      where: {
-        userId: request.user.userId,
-        currentQuestionIndex: 0,
-      },
-      orderBy: {
-        createdAt: 'desc', // 최신순으로 정렬
-      },
-    })
-    reply.send(sessions)
+    const interviews = await fastify.interviewService.getUserInterviews(
+      request.user.userId,
+    )
+    reply.send(interviews)
   }
 
-  fastify.get(routePath, opts, handler)
+  fastify.route({
+    onRequest: [fastify.authenticate],
+    method: 'GET',
+    url: '/',
+    schema,
+    handler,
+  })
 }
-export default route
+export default controller

--- a/apps/core-api/src/schemas/rest/interview.ts
+++ b/apps/core-api/src/schemas/rest/interview.ts
@@ -1,12 +1,18 @@
+import { InterviewSessionStatus } from '@prisma/client'
 import { Type } from '@sinclair/typebox'
 
 import SchemaId from '@/utils/schemaId'
 
-export const interviewSchema = Type.Object(
+// GET /api/v1/interviews 응답의 각 항목에 대한 스키마
+export const interviewListItemSchema = Type.Object(
   {
     id: Type.String({
       description: '면접 세션의 고유 ID',
       example: 'clxxtkv0w0000a4z0b1c2d3e4',
+    }),
+    title: Type.String({
+      description: '면접 세션 제목',
+      example: '네이버 interview 1',
     }),
     company: Type.String({
       description: '회사명',
@@ -20,10 +26,32 @@ export const interviewSchema = Type.Object(
       description: '세부 직무',
       example: 'Backend Developer',
     }),
+    status: Type.Enum(InterviewSessionStatus, {
+      description: '면접 세션의 현재 상태',
+      example: 'READY',
+    }),
     currentQuestionIndex: Type.Number({
       description: '현재 진행 중인 질문의 인덱스 (0부터 시작)',
       example: 0,
     }),
+    idealTalent: Type.Optional(
+      Type.String({
+        description: '회사 인재상',
+        example: '열정적이고 협업을 잘하는 개발자',
+      }),
+    ),
+    coverLetterFilename: Type.Optional(
+      Type.String({
+        description: '제출된 자기소개서 파일명',
+        example: 'my_cover_letter.pdf',
+      }),
+    ),
+    portfolioFilename: Type.Optional(
+      Type.String({
+        description: '제출된 포트폴리오 파일명',
+        example: 'my_portfolio.pdf',
+      }),
+    ),
     createdAt: Type.String({
       format: 'date-time',
       description: '생성 일시',
@@ -33,5 +61,10 @@ export const interviewSchema = Type.Object(
       description: '마지막 업데이트 일시',
     }),
   },
-  { $id: SchemaId.Interview },
+  { $id: SchemaId.InterviewListItem },
 )
+
+// GET /api/v1/interviews 응답 전체에 대한 스키마
+export const interviewListSchema = Type.Array(interviewListItemSchema, {
+  $id: SchemaId.InterviewList,
+})

--- a/apps/core-api/src/utils/schemaId.ts
+++ b/apps/core-api/src/utils/schemaId.ts
@@ -2,7 +2,8 @@ enum SchemaId {
   // REST Schemas
   Error = 'ErrorResponse',
   User = 'UserResponse',
-  Interview = 'InterviewResponse',
+  InterviewListItem = 'InterviewListItem',
+  InterviewList = 'InterviewList',
 
   // WebSocket Schemas
   WsClientSubmitAnswer = 'WsClientSubmitAnswer',


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-85](https://konkuk-graduation-project.atlassian.net/browse/AIEW-85)
- **Branch**: feature/AIEW-85

---

### 작업 내용 📌

- DB 스키마 변경
  - `InterviewSession`의 `status` 상세화
    - 기존: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`
    - 현재: `PENDING`, `READY`, `IN_PROGRESS`, `COMPLETED`, `FAILED`
  - `InterviewSession`에 `title` 추가
    - `{회사명} interview {count+1}` 로 자동 생성
- Model 스키마 변경
  - `interviewSession`의 변경을 반영하고 다음 요소를 추가로 클라이언트에 반환
    - `status`, `idealTalent`, `coverLetterFilename`, `portfolioFilename`
    - #53 에서의 요구사항 반영
- 면접 세션 조회 리팩토링
  - 조회 로직을 우선 서비스로 이동
  - `repository` 레이어는 추후 적용 예정

---

### 변경사항 🖥️

| 인터뷰 전체 조회 화면 |
| --- |
| <img width="720" height="450" alt="image" src="https://github.com/user-attachments/assets/e7441530-3d5e-45dc-a32d-ee9ab1899b25" /> |

---

### 테스트 방법 🧑🏻‍🔬

```bash
pnpm install
pnpm dev
```
- [면접 생성](http://localhost:4000/interview/create) 페이지에서 동일한 회사명으로 여러 세션 생성
- [전체 인터뷰 조회](http://localhost:4000/interview) 페이지에서 `title` 및 `status` 확인
- [Swagger](http://localhost:3000/docs#/%F0%9F%97%A3%EF%B8%8F%20%EB%A9%B4%EC%A0%91)에서 면접 세션 전체 조회, 단일 조회 테스트 

---

### 참고 사항 📂

- `PENDING`인 면접 세션 카드는 질문 생성 완료 후 새로고침하면 `READY`로 변경됩니다


[AIEW-85]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ