### PR TITLE
AIEW-86 interview 상태 관리

### DIFF
--- a/apps/web-client/src/app/(main)/interview/_components/FooterButtons.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/FooterButtons.tsx
@@ -5,18 +5,25 @@ export default function FooterButtons({
   isWaiting = false,
   onClick,
   isQuestionsReady = false,
+  destroySocket,
 }: {
   isWaiting?: boolean
   onClick?: () => void
   isQuestionsReady?: boolean
+  destroySocket?: () => void
 }) {
   const router = useRouter()
+
+  function handleBackButton() {
+    destroySocket?.()
+    router.push('/interview')
+  }
 
   return (
     <div className="w-full h-48 flex gap-24 flex-none">
       <button
         type="button"
-        onClick={() => router.push('/interview')}
+        onClick={handleBackButton}
         className="flex-3 rounded-[10px] border border-neutral-subtext text-neutral-subtext hover:shadow-md hover:cursor-pointer"
       >
         back

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
+import InterviewStatusChip from './InterviewStatusChip'
+
 export type Interview = {
   id: string
   title: string
@@ -8,7 +10,7 @@ export type Interview = {
   jobTitle: string
   jobSpec: string
   createdAt: string
-  status?: 'ready' | 'draft' | 'done'
+  status: InterviewStatus
 }
 
 export default function InterviewCard({
@@ -18,15 +20,7 @@ export default function InterviewCard({
   data: Interview
   onDelete?: (id: string) => void
 }) {
-  const {
-    id,
-    title,
-    company,
-    jobTitle,
-    jobSpec,
-    createdAt,
-    status = 'ready',
-  } = data
+  const { id, title, company, jobTitle, jobSpec, createdAt, status } = data
 
   return (
     <article className="relative min-w-50 min-h-280 p-24 rounded-[20px] bg-neutral-card flex flex-col justify-between shadow-box">
@@ -41,9 +35,7 @@ export default function InterviewCard({
       {/* 질문 준비 상태와 날짜 */}
       {/* TODO: 상태값 변화 어떻게 인식할지 */}
       <header className="w-full flex justify-between items-center">
-        <div className="px-28 text-neutral-inverse bg-success rounded-full inline-flex items-center h-32">
-          {status}
-        </div>
+        <InterviewStatusChip status={status} />
         <span className="text-neutral-subtext">
           {new Date(createdAt).toISOString().split('T')[0]}
         </span>

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
@@ -1,7 +1,12 @@
+'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
 import InterviewStatusChip from './InterviewStatusChip'
+
+import { privateFetch } from '@/app/lib/fetch'
 
 export type Interview = {
   id: string
@@ -20,11 +25,36 @@ export default function InterviewCard({
   data: Interview
   onDelete?: (id: string) => void
 }) {
-  const { id, title, company, jobTitle, jobSpec, createdAt, status } = data
+  const [interview, setInterview] = useState(data)
+
+  // interview 상태가 PENDING이 아닐 때까지 상태를 polling
+  useEffect(() => {
+    if (interview.status !== 'PENDING') return
+
+    const interval = setInterval(async () => {
+      try {
+        const res = await privateFetch(
+          `${process.env.NEXT_PUBLIC_API_BASE}/interviews/${interview.id}`,
+          { cache: 'no-store' }, // 항상 fresh fetch
+        )
+        const updated = await res.json()
+        setInterview(updated)
+
+        if (updated.status !== 'PENDING') {
+          clearInterval(interval) // READY or FAILED 되면 중단
+        }
+      } catch (err) {
+        console.error('Failed to fetch interview:', err)
+      }
+    }, 2000) // 2초마다 polling
+
+    return () => clearInterval(interval)
+  }, [interview.id, interview.status])
+
+  const { id, title, company, jobTitle, jobSpec, createdAt, status } = interview
 
   return (
     <article className="relative min-w-50 min-h-280 p-24 rounded-[20px] bg-neutral-card flex flex-col justify-between shadow-box">
-      {/* InterviewCard 클릭시 waiting room으로 이동 */}
       <Link
         href={`/interview/waiting/${id}`}
         className="absolute inset-0 rounded-[20px] z-0"
@@ -32,8 +62,6 @@ export default function InterviewCard({
         <span className="sr-only">인터뷰 대기 화면으로 이동</span>
       </Link>
 
-      {/* 질문 준비 상태와 날짜 */}
-      {/* TODO: 상태값 변화 어떻게 인식할지 */}
       <header className="w-full flex justify-between items-center">
         <InterviewStatusChip status={status} />
         <span className="text-neutral-subtext">

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewStatusChip.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewStatusChip.tsx
@@ -10,7 +10,6 @@ export default function InterviewStatusChip({
     IN_PROGRESS: 'bg-neutral-subtext',
     COMPLETED: 'bg-neutral-subtext',
   }
-  console.log(status)
   return (
     <div
       className={`w-96 h-32 flex justify-center items-center rounded-full text-neutral-inverse ${STATUS_STYLES[status]}`}

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewStatusChip.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewStatusChip.tsx
@@ -1,0 +1,21 @@
+export default function InterviewStatusChip({
+  status,
+}: {
+  status: InterviewStatus
+}) {
+  const STATUS_STYLES = {
+    PENDING: 'bg-warning',
+    READY: 'bg-success',
+    FAILED: 'bg-error',
+    IN_PROGRESS: 'bg-neutral-subtext',
+    COMPLETED: 'bg-neutral-subtext',
+  }
+  console.log(status)
+  return (
+    <div
+      className={`w-96 h-32 flex justify-center items-center rounded-full text-neutral-inverse ${STATUS_STYLES[status]}`}
+    >
+      {status.toLowerCase()}
+    </div>
+  )
+}

--- a/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/components/LoadingCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/components/LoadingCard.tsx
@@ -8,7 +8,7 @@ import LoadingCircle from './LoadingCircle'
 import { useInterviewSocket } from '@/app/hooks/useInterviewSocket'
 
 export default function LoadingCard({ sessionId }: { sessionId: string }) {
-  const { isQuestionsReady } = useInterviewSocket(sessionId)
+  const { isQuestionsReady, destroySocket } = useInterviewSocket(sessionId)
   return (
     <Card className="w-full h-full flex flex-col items-center justify-center relative">
       <div className="flex-1 flex flex-col items-center justify-center gap-48">
@@ -26,7 +26,11 @@ export default function LoadingCard({ sessionId }: { sessionId: string }) {
             : 'preparing interview...'}
         </span>
       </div>
-      <FooterButtons isWaiting isQuestionsReady={isQuestionsReady} />
+      <FooterButtons
+        isWaiting
+        isQuestionsReady={isQuestionsReady}
+        destroySocket={destroySocket}
+      />
     </Card>
   )
 }

--- a/apps/web-client/src/app/hooks/useInterviewSocket.ts
+++ b/apps/web-client/src/app/hooks/useInterviewSocket.ts
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 
-import { getSocket } from '../lib/socket'
+import { getSocket, destroySocket } from '../lib/socket'
 
 // 최종 이벤트 payload
 export interface QuestionsReadyPayload {
@@ -39,5 +39,10 @@ export function useInterviewSocket(sessionId?: string) {
     }
   }, [socket, sessionId])
 
-  return { socket, isConnected: !!socket?.connected, isQuestionsReady }
+  return {
+    socket,
+    destroySocket,
+    isConnected: !!socket?.connected,
+    isQuestionsReady,
+  }
 }

--- a/apps/web-client/src/app/lib/fetch.ts
+++ b/apps/web-client/src/app/lib/fetch.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers'
 import { RedirectType } from 'next/navigation'
 
 /**
@@ -15,6 +14,7 @@ export async function privateFetch<T>(
 
   if (isServer) {
     // 서버 환경일 경우, 'next/headers'에서 쿠키를 가져와 수동으로 헤더에 추가합니다.
+    const { cookies } = await import('next/headers')
     const cookieStore = await cookies()
     const cookieHeader = cookieStore
       .getAll()

--- a/apps/web-client/types/interview-types.d.ts
+++ b/apps/web-client/types/interview-types.d.ts
@@ -11,6 +11,14 @@ declare global {
 
   // payload의 questions 필드 타입
   type QuestionsMap = Record<QuestionCategory, QuestionBundles>
+
+  // interview 상태
+  type InterviewStatus =
+    | 'PENDING'
+    | 'READY'
+    | 'IN_PROGRESS'
+    | 'COMPLETED'
+    | 'FAILED'
 }
 
 export {}


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-86](https://konkuk-graduation-project.atlassian.net/browse/AIEW-86)
- **Branch**: feature/AIEW-86

---

### 작업 내용 📌

- 인터뷰 질문 상태 관리
- waiting room 나갈 경우 websocket 연결 해제

---

### 주요 변경 사항 ✍️

- **interview 상태 관리:**
  - 초기 상태가 PENDING인 Interview Card 한해서만 2초마다 상태 polling 진행
  - 상태가 PENDING이 아닐 경우 polling 중지

---

### 변경사항 🖥️

<img width="1254" height="705" alt="Screenshot 2025-09-06 at 2 04 47 PM" src="https://github.com/user-attachments/assets/f1811a31-00e2-4459-b8b7-af1d032fe78a" />

---

### 테스트 방법 🧑🏻‍🔬

(리뷰어가 이 변경사항을 어떻게 테스트하고 검증할 수 있는지 설명합니다.)

- `pnpm dev` 실행
- [인터뷰 생성](http://localhost:4000/interview/create) page에서 인터뷰 생성
- waiting room 에서 `back` 버튼 클릭
- 방금 생성한 interview의 상태가 pending인지 확인
- 상태가 ready로 변경되는지 확인
- api 로그에 Socket disconnected 되어 있는지 확인

---

### 참고 사항 📂

- 마지막 commit인 privateFetch 수정은 이전 pr과 동일합니다. 정상적으로 테스트를 진행할 수 있도록 중복되지만 다시 올렸습니다


[AIEW-86]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ