### PR TITLE
[AIEW-91] interview crud api 반영

### DIFF
--- a/apps/core-api/src/plugins/services/interview.ts
+++ b/apps/core-api/src/plugins/services/interview.ts
@@ -255,21 +255,11 @@ export class InterviewService {
       orderBy: { createdAt: 'desc' },
     })
 
-    // 파일명 추출 로직 추가
-    return sessions.map((session) => {
-      const coverLetterFilename = session.coverLetter
-        ? this.extractFilenameFromUrl(session.coverLetter)
-        : undefined
-      const portfolioFilename = session.portfolio
-        ? this.extractFilenameFromUrl(session.portfolio)
-        : undefined
-
-      return {
-        ...session,
-        coverLetterFilename,
-        portfolioFilename,
-      }
-    })
+    // 파일명 추출 로직 추가 (헬퍼 사용)
+    return sessions.map((session) => ({
+      ...session,
+      ...this.getFileNamesFromSession(session),
+    }))
   }
 
   /**
@@ -284,7 +274,13 @@ export class InterviewService {
         userId: userId,
       },
     })
-    return session
+
+    return (
+      session && {
+        ...session,
+        ...this.getFileNamesFromSession(session),
+      }
+    )
   }
 
   /**
@@ -469,6 +465,23 @@ export class InterviewService {
     const filenameWithPrefix = parts[parts.length - 1]
     // 첫 두 개의 '-' (sessionId-, key-) 이후의 모든 것을 반환
     return filenameWithPrefix.split('-').slice(2).join('-')
+  }
+
+  /**
+   * 세션 객체에서 원본 파일명을 추출해 반환합니다.
+   */
+  private getFileNamesFromSession(session?: {
+    coverLetter: string | null
+    portfolio: string | null
+  }) {
+    const coverLetterFilename = session?.coverLetter
+      ? this.extractFilenameFromUrl(session.coverLetter)
+      : undefined
+    const portfolioFilename = session?.portfolio
+      ? this.extractFilenameFromUrl(session.portfolio)
+      : undefined
+
+    return { coverLetterFilename, portfolioFilename }
   }
 
   private async uploadFilesToR2(

--- a/apps/core-api/src/server.ts
+++ b/apps/core-api/src/server.ts
@@ -51,6 +51,7 @@ const start = async () => {
   })
   await app.register(Cors, {
     origin: 'http://localhost:4000',
+    methods: ['GET', 'POST', 'PATCH', 'DELETE'],
     credentials: true, // Allow cookies to be sent
   })
 

--- a/apps/web-client/next.config.ts
+++ b/apps/web-client/next.config.ts
@@ -50,4 +50,12 @@ const nextConfig: NextConfig = {
   },
 }
 
+module.exports = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '15mb',
+    },
+  },
+}
+
 export default nextConfig

--- a/apps/web-client/src/app/(main)/interview/_components/Carousel.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/Carousel.tsx
@@ -3,7 +3,7 @@
 import useEmblaCarousel from 'embla-carousel-react'
 import { useMemo, useState } from 'react'
 
-import InterviewCard, { Interview } from './InterviewCard'
+import InterviewCard from './InterviewCard'
 
 import {
   NextButton,
@@ -47,7 +47,6 @@ export default function EmblaCarousel({ cards }: { cards: Interview[] }) {
 
       return next
     })
-    // TODO:: 실제로 데이터 삭제하기
   }
 
   const dot = `w-8 h-8 rounded-full bg-gray-300`

--- a/apps/web-client/src/app/(main)/interview/_components/EditDeleteButtons.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/EditDeleteButtons.tsx
@@ -2,13 +2,43 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+
+import { privateFetch } from '@/app/lib/fetch'
 export default function EditDeleteButtons({
   id,
   onDeleteClick,
 }: {
   id: string
-  onDeleteClick: () => void
+  onDeleteClick?: (id?: string) => void
 }) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const handleDelete = async () => {
+    //TODO:: 추후 커스텀한 modal 창 생성
+    if (!confirm('정말 삭제하시겠습니까?')) return
+    try {
+      const res = await privateFetch(
+        `${process.env.NEXT_PUBLIC_API_BASE}/interviews/${id}`,
+        {
+          method: 'DELETE',
+        },
+      )
+
+      if (res.ok) {
+        // 부모로 삭제 이벤트 전달
+        onDeleteClick?.(id)
+
+        //만약 interview page가 아니라면 interview page로 redirect
+        console.log(pathname)
+        if (pathname !== '/interview') router.replace('/interview')
+      } else {
+        console.error('Failed to delete interview:', await res.text())
+      }
+    } catch (err) {
+      console.error('Error deleting interview:', err)
+    }
+  }
   return (
     <>
       <Link
@@ -25,7 +55,7 @@ export default function EditDeleteButtons({
         className="px-10 text-error flex items-center justify-center gap-6 z-10"
         onClick={(e) => {
           e.preventDefault()
-          onDeleteClick()
+          handleDelete()
         }}
       >
         <Image

--- a/apps/web-client/src/app/(main)/interview/_components/EditDeleteButtons.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/EditDeleteButtons.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+export default function EditDeleteButtons({
+  id,
+  onDeleteClick,
+}: {
+  id: string
+  onDeleteClick: () => void
+}) {
+  return (
+    <>
+      <Link
+        type="button"
+        className="px-10 text-neutral-subtext flex items-center justify-center gap-6 z-10"
+        href={`/interview/create/${id}`}
+      >
+        <Image src="/icons/edit.svg" alt="edit icon" width={12} height={12} />
+        edit
+      </Link>
+
+      <button
+        type="button"
+        className="px-10 text-error flex items-center justify-center gap-6 z-10"
+        onClick={(e) => {
+          e.preventDefault()
+          onDeleteClick()
+        }}
+      >
+        <Image
+          src="/icons/delete.svg"
+          alt="delete icon"
+          width={12}
+          height={12}
+        />
+        delete
+      </button>
+    </>
+  )
+}

--- a/apps/web-client/src/app/(main)/interview/_components/FooterButtons.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/FooterButtons.tsx
@@ -2,11 +2,13 @@
 import { useRouter } from 'next/navigation'
 
 export default function FooterButtons({
+  isEdit = false,
   isWaiting = false,
   onClick,
   isQuestionsReady = false,
   destroySocket,
 }: {
+  isEdit?: boolean
   isWaiting?: boolean
   onClick?: () => void
   isQuestionsReady?: boolean
@@ -36,7 +38,11 @@ export default function FooterButtons({
         disabled:hover:shadow-none disabled:opacity-50
     disabled:cursor-not-allowed"
       >
-        {isWaiting ? 'start interview' : 'create interview'}
+        {isWaiting
+          ? 'start interview'
+          : isEdit
+            ? 'edit interview'
+            : 'create interview'}
       </button>
     </div>
   )

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
@@ -41,26 +41,13 @@ export default function InterviewCard({
     return () => clearInterval(interval)
   }, [interview.id, interview.status])
 
-  const handleDelete = async () => {
-    //TODO:: 추후 커스텀한 modal 창 생성
-    if (!confirm('정말 삭제하시겠습니까?')) return
-    try {
-      const res = await privateFetch(
-        `${process.env.NEXT_PUBLIC_API_BASE}/interviews/${interview.id}`,
-        {
-          method: 'DELETE',
-        },
-      )
-
-      if (res.ok) {
-        // 부모로 삭제 이벤트 전달
-        onDelete?.(interview.id)
-      } else {
-        console.error('Failed to delete interview:', await res.text())
-      }
-    } catch (err) {
-      console.error('Error deleting interview:', err)
+  const handleDelete = (id?: string) => {
+    if (!id) {
+      console.error('id가 필요합니다')
+      return
     }
+    //Carousel에서 삭제
+    onDelete?.(id)
   }
 
   const { id, title, company, jobTitle, jobSpec, createdAt, status } = interview

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
@@ -8,16 +8,6 @@ import InterviewStatusChip from './InterviewStatusChip'
 
 import { privateFetch } from '@/app/lib/fetch'
 
-export type Interview = {
-  id: string
-  title: string
-  company: string
-  jobTitle: string
-  jobSpec: string
-  createdAt: string
-  status: InterviewStatus
-}
-
 export default function InterviewCard({
   data,
   onDelete,

--- a/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
+++ b/apps/web-client/src/app/(main)/interview/_components/InterviewCard.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
+import EditDeleteButtons from './EditDeleteButtons'
 import InterviewStatusChip from './InterviewStatusChip'
 
 import { privateFetch } from '@/app/lib/fetch'
@@ -40,6 +40,28 @@ export default function InterviewCard({
 
     return () => clearInterval(interval)
   }, [interview.id, interview.status])
+
+  const handleDelete = async () => {
+    //TODO:: 추후 커스텀한 modal 창 생성
+    if (!confirm('정말 삭제하시겠습니까?')) return
+    try {
+      const res = await privateFetch(
+        `${process.env.NEXT_PUBLIC_API_BASE}/interviews/${interview.id}`,
+        {
+          method: 'DELETE',
+        },
+      )
+
+      if (res.ok) {
+        // 부모로 삭제 이벤트 전달
+        onDelete?.(interview.id)
+      } else {
+        console.error('Failed to delete interview:', await res.text())
+      }
+    } catch (err) {
+      console.error('Error deleting interview:', err)
+    }
+  }
 
   const { id, title, company, jobTitle, jobSpec, createdAt, status } = interview
 
@@ -80,38 +102,7 @@ export default function InterviewCard({
 
       <footer className="flex justify-between items-center h-40">
         <div className="flex gap-8 h-32">
-          <button
-            type="button"
-            className="px-10 text-neutral-subtext flex items-center justify-center gap-6 z-10"
-            onClick={(e) => {
-              e.preventDefault()
-              // TODO: open edit screen
-            }}
-          >
-            <Image
-              src="/icons/edit.svg"
-              alt="edit icon"
-              width={12}
-              height={12}
-            />
-            edit
-          </button>
-          <button
-            type="button"
-            className="px-10 text-error flex items-center justify-center gap-6 z-10"
-            onClick={(e) => {
-              e.preventDefault()
-              onDelete?.(id)
-            }}
-          >
-            <Image
-              src="/icons/delete.svg"
-              alt="delete icon"
-              width={12}
-              height={12}
-            />
-            delete
-          </button>
+          <EditDeleteButtons id={id} onDeleteClick={handleDelete} />
         </div>
         <Link
           className="bg-primary rounded-[10px] text-neutral-inverse px-20 h-40 flex items-center justify-center z-10"

--- a/apps/web-client/src/app/(main)/interview/create/Form.tsx
+++ b/apps/web-client/src/app/(main)/interview/create/Form.tsx
@@ -15,7 +15,7 @@ export default function InterviewForm({
   interview?: Interview
 }) {
   //interview가 존재하면 수정하는 것임
-  const isEdit = !!interview && interview.id
+  const isEdit = !!interview && !!interview.id
   const [job, setJob] = useState(interview?.jobTitle)
 
   // Dropzone containers and selected files

--- a/apps/web-client/src/app/(main)/interview/create/Form.tsx
+++ b/apps/web-client/src/app/(main)/interview/create/Form.tsx
@@ -5,16 +5,28 @@ import { useState, useRef } from 'react'
 import Card from '../_components/Card'
 import FooterButtons from '../_components/FooterButtons'
 
-import { createInterview } from './action'
+import { createInterview, patchInterview } from './action'
 import DropzoneBox from './component/DropzoneBox'
 import { Label } from './component/Label'
 
-export default function InterviewForm() {
-  const [job, setJob] = useState('')
+export default function InterviewForm({
+  interview,
+}: {
+  interview?: Interview
+}) {
+  //interview가 존재하면 수정하는 것임
+  const isEdit = !!interview && interview.id
+  const [job, setJob] = useState(interview?.jobTitle)
 
   // Dropzone containers and selected files
   const resumeFileRef = useRef<File | null>(null)
   const portfolioFileRef = useRef<File | null>(null)
+
+  //수정시 Dropzone에 기존 file의 이름을 보여줌
+  if (isEdit) {
+    resumeFileRef.current = new File([], interview.coverLetterFilename)
+    portfolioFileRef.current = new File([], interview.portfolioFilename)
+  }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -24,7 +36,11 @@ export default function InterviewForm() {
     if (portfolioFileRef.current)
       formData.append('portfolio', portfolioFileRef.current)
     try {
-      await createInterview(formData)
+      if (isEdit) {
+        await patchInterview(formData, interview)
+      } else {
+        await createInterview(formData)
+      }
     } catch (error) {
       console.error('면접 생성 실패:', error)
     }
@@ -38,6 +54,17 @@ export default function InterviewForm() {
       {/* 왼쪽 card
        직업, 회사명, 인재상을 입력함*/}
       <Card className="flex-1 flex flex-col justify-between">
+        {isEdit && (
+          <Label text="Title">
+            <input
+              type="text"
+              name="title"
+              className="mt-1 block w-full h-48 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 hover:shadow-md"
+              placeholder="Enter Title"
+              defaultValue={interview?.title}
+            />
+          </Label>
+        )}
         <Label text="Job">
           <select
             name="jobTitle"
@@ -62,6 +89,7 @@ export default function InterviewForm() {
             <select
               name="jobSpec"
               className="mt-1 block w-full h-48 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 hover:shadow-md"
+              defaultValue={interview?.jobSpec}
             >
               <option value="" hidden>
                 Select
@@ -78,6 +106,7 @@ export default function InterviewForm() {
             name="company"
             className="mt-1 block w-full h-48 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 hover:shadow-md"
             placeholder="Enter company name"
+            defaultValue={interview?.company}
           />
         </Label>
         <Label text="Ideal Talent" className="basis-[40%] flex flex-col">
@@ -85,6 +114,7 @@ export default function InterviewForm() {
             name="idealTalent"
             className="mt-1 block w-full flex-1 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 resize-none hover:shadow-md"
             placeholder="Describe the ideal talent"
+            defaultValue={interview?.idealTalent}
           ></textarea>
         </Label>
       </Card>
@@ -100,7 +130,7 @@ export default function InterviewForm() {
             <DropzoneBox fileRef={portfolioFileRef} className="flex-1" />
           </Label>
         </div>
-        <FooterButtons />
+        <FooterButtons isEdit={isEdit} />
       </Card>
     </form>
   )

--- a/apps/web-client/src/app/(main)/interview/create/[[...sessionId]]/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/create/[[...sessionId]]/page.tsx
@@ -1,0 +1,26 @@
+import Form from '../Form'
+
+import { privateFetch } from '@/app/lib/fetch'
+
+export default async function CreateInterviewPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>
+}) {
+  const { sessionId } = await params
+
+  const fetchInterview = async () => {
+    const response = await privateFetch(
+      process.env.NEXT_PUBLIC_API_BASE + '/interviews/' + sessionId,
+    )
+    return await response.json()
+  }
+
+  const interview = sessionId && sessionId[0] && (await fetchInterview())
+
+  return (
+    <div className="w-full h-full p-24">
+      {sessionId && sessionId[0] ? <Form interview={interview} /> : <Form />}
+    </div>
+  )
+}

--- a/apps/web-client/src/app/(main)/interview/create/action.ts
+++ b/apps/web-client/src/app/(main)/interview/create/action.ts
@@ -4,6 +4,22 @@ import { redirect } from 'next/navigation'
 
 import { privateFetch } from '@/app/lib/fetch'
 
+function redirectToWaiting(id: string) {
+  redirect(`/interview/waiting/${id}`)
+}
+
+function appendFiles(formData: FormData, newFormData: FormData) {
+  const coverLetter = formData.get('coverLetter')
+  if (coverLetter instanceof File && coverLetter.size > 0) {
+    newFormData.append('coverLetter', coverLetter)
+  }
+
+  const portfolio = formData.get('portfolio')
+  if (portfolio instanceof File && portfolio.size > 0) {
+    newFormData.append('portfolio', portfolio)
+  }
+}
+
 export async function createInterview(formData: FormData) {
   const newFormData = new FormData()
 
@@ -24,22 +40,15 @@ export async function createInterview(formData: FormData) {
     JSON.stringify({ value: formData.get('idealTalent') }),
   )
 
-  const coverLetter = formData.get('coverLetter')
-  if (coverLetter instanceof File && coverLetter.size > 0) {
-    newFormData.append('coverLetter', coverLetter)
-  }
+  appendFiles(formData, newFormData)
 
-  const portfolio = formData.get('portfolio')
-  if (portfolio instanceof File && portfolio.size > 0) {
-    newFormData.append('portfolio', portfolio)
-  }
-
-  console.log('newFormData', newFormData)
-
-  const res = await privateFetch('http://localhost:3000/api/v1/interviews', {
-    method: 'POST',
-    body: newFormData,
-  })
+  const res = await privateFetch(
+    `${process.env.NEXT_PUBLIC_API_BASE}/interviews`,
+    {
+      method: 'POST',
+      body: newFormData,
+    },
+  )
 
   if (!res.ok) {
     throw new Error('면접 생성에 실패했습니다.')
@@ -47,5 +56,44 @@ export async function createInterview(formData: FormData) {
 
   const { sessionId } = await res.json()
   console.log('sessionId', sessionId)
-  redirect(`/interview/waiting/${sessionId}`)
+  redirectToWaiting(sessionId)
+}
+
+export async function patchInterview(formData: FormData, interview: Interview) {
+  const newFormData = new FormData()
+
+  const EDITABLE_KEYS = [
+    'title',
+    'company',
+    'jobTitle',
+    'jobSpec',
+    'idealTalent',
+  ] as const
+
+  //기존 interview와 다른 값일 경우에만 newFormData에 포함시킴
+  for (const key of EDITABLE_KEYS) {
+    const raw = formData.get(key)
+    const newVal = typeof raw === 'string' ? raw : null
+    const oldVal = interview[key] // string
+
+    if (newVal !== null && newVal !== oldVal) {
+      newFormData.append(key, JSON.stringify({ set: newVal }))
+    }
+  }
+
+  //size > 0 이면 새로운 파일임을 의미
+  appendFiles(formData, newFormData)
+
+  //변경된 값이 없을 경우 바로 waiting room으로 넘어감
+  if ([...newFormData.keys()].length === 0) {
+    console.log('No changes detected')
+    redirectToWaiting(interview.id)
+  }
+
+  const res = await privateFetch(
+    `${process.env.NEXT_PUBLIC_API_BASE}/interviews/${interview.id}`,
+    { method: 'PATCH', body: newFormData },
+  )
+  if (!res.ok) throw new Error('면접 수정에 실패했습니다.')
+  redirectToWaiting(interview.id)
 }

--- a/apps/web-client/src/app/(main)/interview/create/component/DropzoneBox.tsx
+++ b/apps/web-client/src/app/(main)/interview/create/component/DropzoneBox.tsx
@@ -98,9 +98,12 @@ const FilePreview: React.FC<FilePreviewProps> = ({ file, onRemove }) => {
         <span className="font-medium truncate" title={file.name}>
           {file.name}
         </span>
-        <span className="text-gray-500 text-xs">
-          {(file.size / 1024 / 1024).toFixed(2)} MB
-        </span>
+        {/* 파일의 크기가 존재할 경우에만 표시 */}
+        {file.size !== 0 && (
+          <span className="text-gray-500 text-xs">
+            {(file.size / 1024 / 1024).toFixed(2)} MB
+          </span>
+        )}
       </div>
       <button
         type="button"

--- a/apps/web-client/src/app/(main)/interview/create/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/create/page.tsx
@@ -1,9 +1,0 @@
-import Form from './Form'
-
-export default async function CreateInterviewPage() {
-  return (
-    <div className="w-full h-full p-24">
-      <Form />
-    </div>
-  )
-}

--- a/apps/web-client/src/app/(main)/interview/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 
 import Carousel from './_components/Carousel'
-import { Interview } from './_components/InterviewCard'
 
 import { privateFetch } from '@/app/lib/fetch'
 

--- a/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/page.tsx
@@ -1,4 +1,5 @@
 import Card from '../../_components/Card'
+import EditDeleteButtons from '../../_components/EditDeleteButtons'
 
 import InfoItem from './components/InfoItem'
 import LoadingCard from './components/LoadingCard'
@@ -13,12 +14,11 @@ export default async function WaitingPage({
   const { sessionId } = await params
   const response = await privateFetch(
     process.env.NEXT_PUBLIC_API_BASE + '/interviews/' + sessionId,
+    { cache: 'no-store' },
   )
   const interview: Interview = await response.json()
-  console.log('WaitingPage sessionId:', sessionId)
   return (
     <div className="w-full h-full flex flex-col lg:flex-row p-24 gap-24">
-      {/* TODO:: title, 인재상, resume, portfolio 제목 받아오기 */}
       <Card className="w-full h-full flex flex-col">
         <span className="text-right text-gray-500">
           {new Date(interview.createdAt)
@@ -38,6 +38,9 @@ export default async function WaitingPage({
           <InfoItem label="resume" value={interview.coverLetterFilename} />
           <InfoItem label="portfolio" value={interview.portfolioFilename} />
         </dl>
+        <div className="flex justify-end">
+          <EditDeleteButtons id={sessionId} />
+        </div>
       </Card>
       <LoadingCard sessionId={sessionId} />
     </div>

--- a/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/waiting/[sessionId]/page.tsx
@@ -1,5 +1,4 @@
 import Card from '../../_components/Card'
-import { Interview } from '../../_components/InterviewCard'
 
 import InfoItem from './components/InfoItem'
 import LoadingCard from './components/LoadingCard'
@@ -26,14 +25,18 @@ export default async function WaitingPage({
             .toLocaleString('sv-SE')
             .replace('T', ' ')}
         </span>
-        <h1 className="text-[32px] font-bold">{'title'}</h1>
+        <h1 className="text-[32px] font-bold">{interview.title}</h1>
         <dl className="flex flex-col flex-1 pt-24 gap-24">
           <InfoItem label="Job" value={interview.jobTitle} />
           <InfoItem label="Detail Job" value={interview.jobSpec} />
           <InfoItem label="company name" value={interview.company} />
-          <InfoItem label="인재상" value={'성신의'} className="flex-auto" />
-          <InfoItem label="resume" value="resume_digital.pdf" />
-          <InfoItem label="portfolio" value="portfolio_digita.pdf" />
+          <InfoItem
+            label="인재상"
+            value={interview.idealTalent}
+            className="flex-auto"
+          />
+          <InfoItem label="resume" value={interview.coverLetterFilename} />
+          <InfoItem label="portfolio" value={interview.portfolioFilename} />
         </dl>
       </Card>
       <LoadingCard sessionId={sessionId} />

--- a/apps/web-client/src/app/hooks/useDropzoneBox.ts
+++ b/apps/web-client/src/app/hooks/useDropzoneBox.ts
@@ -39,7 +39,8 @@ export default function useDropzoneBox({
   const inputId = useId()
 
   const [dragActive, setDragActive] = useState(false)
-  const [file, setFile] = useState<File | null>(null)
+  //만약 초기값이 존재한다면 그 값을 file로 설정
+  const [file, setFile] = useState<File | null>(() => fileRef?.current ?? null)
   const [error, setError] = useState<string>('')
 
   // keep external ref in sync
@@ -51,6 +52,7 @@ export default function useDropzoneBox({
     setFile(null)
     setError('')
     if (inputRef.current) inputRef.current.value = ''
+    if (fileRef?.current) fileRef.current = null
     e.preventDefault()
     e.stopPropagation()
   }, [])

--- a/apps/web-client/types/interview-types.d.ts
+++ b/apps/web-client/types/interview-types.d.ts
@@ -19,6 +19,21 @@ declare global {
     | 'IN_PROGRESS'
     | 'COMPLETED'
     | 'FAILED'
+
+  type Interview = {
+    id: string
+    title: string
+    company: string
+    jobTitle: string
+    jobSpec: string
+    status: InterviewStatus
+    currentQuestionIndex: number
+    idealTalent: string
+    coverLetterFilename: string
+    portfolioFilename: string
+    createdAt: string
+    updatedAt: string
+  }
 }
 
 export {}


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-91](https://konkuk-graduation-project.atlassian.net/browse/AIEW-91)
- **Branch**: feature/AIEW-91

---

### 작업 내용 📌

- interview 삭제 가능
- interview 수정 가능

---

### 주요 변경 사항 ✍️

**filename 반환 b22c71bbc7ae94ed275ddfcbf896f392f5e2825c**
- /api/v1/interviews/{sessionId} 에서 filename을 반환 못하는 문제가 있었음
- response type이 coverLetterFilename인데 coverLetter를 반환해서 생긴 문제
- 기존 interviews의 코드를 참고해 문제를 해결함
- 추가적으로 함수로 변경

**interview 수정**
- create page에 interview의 id가 존재하면 이는 수정 상태임
- 수정 시에는 label에 기존 interview값을 넣음
- file 같은 경우는 단순 filename만 가진 가짜 File 객체를 만들어 사용자에게 preview로 표시
- 수정시 기존 데이터와 다른 경우에만 patch 수행
  - file은 size > 0인 경우에만 patch 수행
  - 초기값은 file size 가 0이기 때문
- 수정 데이터가 없을 경우에는 단순 waiting page로 redirect

---

### 변경사항 🖥️

<img width="1184" height="687" alt="image" src="https://github.com/user-attachments/assets/bace96b1-a5d5-4c9a-995c-7d069a70dccb" />

---

### 테스트 방법 🧑🏻‍🔬

1. `pnpm dev` 실행
2. [interview page](http://localhost:4000/interview) 접속
3. interview가 없을 경우 interview 생성
4. interivew edit 버튼 클릭
5. interview를 수정한 후 edit interview 클릭
6. 실제로 interview가 잘 수정 됐는지 확인
7. interview delete 버튼 클릭
8. 모달창에서 확인 클릭
9. 실제로 interview가 삭제 됐는지 확인

---

### 참고 사항 📂

현재 생성과 수정시 filename이 바로 반영 안되는 문제가 있습니다.
몇초 후에 새로 고침 하면 filename이 잘 나타나요!
apps/core-api/src/plugins/services/interview.ts 의 processInterviewInBackground 함수의 await를 받지 않아서 생기는 문제라고 파악했습니다.
이 함수 덕분에 session 생성 속도는 정말 빠른데 filename이 바로 안 나타나니..
file만 따로 분리를 해야할지 아니면 
session을 반환할 때 file이 업로드되지 않았지만 filename을 추가하는게 좋을지 고민이 되네요
```
      void this.processInterviewInBackground(
        sessionId,
        fullInterviewData,
        filesForProcessing,
      )
```
