### PR TITLE
[AIEW-98] interview 흐름 구현

### DIFF
--- a/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/AnswerControl.tsx
+++ b/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/AnswerControl.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useShallow } from 'zustand/shallow'
+
+import { useInterviewStore } from '@/app/lib/socket/interviewStore'
+import { useSttStore } from '@/app/lib/socket/sttStore'
+
+export default function AnswerControl() {
+  const sttState = useSttStore()
+  const { current, submitAnswer } = useInterviewStore(
+    useShallow((state) => ({
+      current: state.current,
+      submitAnswer: state.submitAnswer,
+    })),
+  )
+
+  const handleAnswer = async () => {
+    sttState.pauseMic()
+    if (!current) return
+    //TODO:: 면접자가 말한 내용까가 text화 해서 답변 제출할 것
+    //현재는 화면에 표시된 문장만 답변으로 제출
+    const payload = {
+      stepId: current.stepId,
+      answer: sttState.sentences,
+      duration: 30, //TODO:: 시작 시간과 종료 시간 추가
+    }
+    submitAnswer(payload)
+    sttState.disconnect()
+  }
+
+  return (
+    <div>
+      {sttState.isMicPaused ? (
+        <button
+          disabled={!sttState.isSessionActive}
+          onClick={sttState.resumeMic}
+        >
+          답변 시작
+        </button>
+      ) : (
+        <button onClick={handleAnswer}>답변 완료</button>
+      )}
+    </div>
+  )
+}

--- a/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/IntervieweePannel.tsx
+++ b/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/IntervieweePannel.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import EventLog from '../../../stt/[sessionId]/_components/EventLog'
+
+import { useSttStore } from '@/app/lib/socket/sttStore'
+
+export default function IntervieweePannel() {
+  const sentences = useSttStore((state) => state.sentences)
+  const evnets = useSttStore((state) => state.events)
+  return (
+    <div className="overflow-auto">
+      <p>{sentences}</p>
+      <EventLog events={evnets} />
+    </div>
+  )
+}

--- a/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/InterviewerPannel.tsx
+++ b/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/InterviewerPannel.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useInterviewStore } from '@/app/lib/socket/interviewStore'
+
+export default function InterviewerPannel() {
+  const currentQuestion = useInterviewStore((state) => state.current)
+  return <div>{currentQuestion?.text}</div>
+}

--- a/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/page.tsx
+++ b/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/page.tsx
@@ -1,3 +1,14 @@
+import AnswerControl from './_comonents/AnswerControl'
+import IntervieweePannel from './_comonents/IntervieweePannel'
+import InterviewerPannel from './_comonents/InterviewerPannel'
+
 export default function InterviewPage() {
-  return <>인터뷰 진행,</>
+  return (
+    <div className="w-full h-full grid grid-cols-[5fr_2fr] grid-rows-[5fr_1fr] gap-24">
+      <InterviewerPannel />
+      <IntervieweePannel />
+      <AnswerControl />
+      <div className="bg-green-500">interview control</div>
+    </div>
+  )
 }

--- a/apps/web-client/src/app/lib/socket/sttStore.ts
+++ b/apps/web-client/src/app/lib/socket/sttStore.ts
@@ -1,0 +1,177 @@
+import { create } from 'zustand'
+
+import { privateFetch } from '../fetch'
+type sttState = {
+  isSessionActive: boolean
+  events: RealtimeEvent[]
+  sentences: string
+  isMicPaused: boolean
+  canStopSession: boolean
+  connect: (sessionId: string) => void
+  disconnect: () => void
+  pauseMic: () => void
+  resumeMic: () => void
+}
+
+type RealtimeEvent = {
+  type: string
+  event_id?: string
+  timestamp?: string
+  transcript?: string
+} & Record<string, string>
+
+let lastestItemId = ''
+let peerConnection: RTCPeerConnection | null
+let mediaStream: MediaStream | null
+let dataChannel: RTCDataChannel | null
+
+export const useSttStore = create<sttState>((set, get, store) => ({
+  isSessionActive: false,
+  events: [],
+  sentences: '',
+  isMicPaused: true,
+  canStopSession: false,
+  pauseMic: () => {
+    const track = mediaStream?.getAudioTracks?.()[0]
+    if (!track) {
+      console.warn('No local audio track to pause')
+      return
+    }
+    track.enabled = false
+    set({ isMicPaused: true })
+    console.log('마이크 종료')
+  },
+
+  resumeMic: () => {
+    const track = mediaStream?.getAudioTracks?.()[0]
+    if (!track) {
+      console.warn('No local audio track to resume')
+      return
+    }
+    track.enabled = true
+    // setIsMicPaused(false)
+    set({ isMicPaused: false })
+  },
+
+  disconnect: () => {
+    if (!get().canStopSession) {
+      new Error('세션은 모든 작업이 완료된 후에 종료할 수 있습니다')
+    }
+
+    if (dataChannel) {
+      dataChannel.close()
+    }
+
+    if (peerConnection) {
+      peerConnection.getSenders().forEach((sender) => {
+        if (sender.track) {
+          sender.track.stop()
+        }
+      })
+      peerConnection.close()
+    }
+
+    mediaStream = null
+    peerConnection = null
+    dataChannel = null
+    lastestItemId = ''
+    set(store.getInitialState())
+  },
+
+  connect: async (sessionId: string) => {
+    //만약 session이 존재하면 연결을 끊는다
+    if (peerConnection || dataChannel) get().disconnect()
+
+    //Back에서 EPHEMERAL_KEY를 발급 받는다.
+    const response = await privateFetch(
+      process.env.NEXT_PUBLIC_API_BASE +
+        '/interviews/' +
+        sessionId +
+        '/stt-token',
+    )
+    const { data } = await response.json()
+    const EPHEMERAL_KEY = data.value
+
+    // Create a peer connection
+    const pc = new RTCPeerConnection()
+
+    // Add local audio track for microphone input in the browser
+    const ms = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+    })
+
+    // Start muted by default: disable the track BEFORE adding to the PeerConnection
+    const micTrack = ms.getAudioTracks()[0]
+    if (micTrack) {
+      micTrack.enabled = false
+      set({ isMicPaused: true })
+      pc.addTrack(micTrack)
+    } else {
+      console.warn('No audio track found from getUserMedia')
+    }
+
+    // Set up data channel for sending and receiving events
+    const dc: RTCDataChannel = pc.createDataChannel('oai-events')
+
+    // Start the session using the Session Description Protocol (SDP)
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+
+    //OpenAi와 WebRTC 연결 시도
+    //이 때 back에서 session 설정을 잘못하면 연결 실패함
+    const baseUrl = 'https://api.openai.com/v1/realtime/calls'
+    const sdpResponse = await fetch(`${baseUrl}`, {
+      method: 'POST',
+      body: offer.sdp,
+      headers: {
+        Authorization: `Bearer ${EPHEMERAL_KEY}`,
+        'Content-Type': 'application/sdp',
+      },
+    })
+
+    const sdp = await sdpResponse.text()
+    const answer: RTCSessionDescriptionInit = { type: 'answer' as const, sdp }
+    await pc.setRemoteDescription(answer)
+
+    // Append new server events to the list
+    dc.addEventListener('message', (e) => {
+      const event = JSON.parse(e.data) as RealtimeEvent
+      if (!event.timestamp) {
+        event.timestamp = new Date().toLocaleTimeString()
+      }
+
+      //   setEvents((prev) => [event, ...prev])
+      set((prev) => ({ events: [event, ...prev.events] }))
+
+      if (
+        event.type === 'conversation.item.input_audio_transcription.completed'
+      ) {
+        console.log(event.transcript)
+
+        // setSentences((prev) => prev + ' ' + event.transcript)
+        set((prev) => ({ sentences: prev.sentences + ' ' + event.transcript }))
+
+        //모든 문장이 transcription 되어야지 session을 종료할 수 있음
+        if (event.item_id === lastestItemId) {
+          //   setCanStopSession(true)
+          set({ canStopSession: true })
+        }
+      } else if (event.type === 'input_audio_buffer.speech_started') {
+        lastestItemId = event.item_id
+        // setCanStopSession(false)
+        set({ canStopSession: false })
+      }
+    })
+
+    // Set session active when the data channel is opened
+    dc.addEventListener('open', () => {
+      //   setIsSessionActive(true)
+      //   setEvents([])
+      set({ isSessionActive: true, events: [] })
+    })
+
+    peerConnection = pc
+    mediaStream = ms
+    dataChannel = dc
+  },
+}))

--- a/apps/web-client/src/app/lib/socket/types.ts
+++ b/apps/web-client/src/app/lib/socket/types.ts
@@ -10,7 +10,7 @@ export type ServerEvent =
   | 'server:error'
 
 // 클라이언트에서 보내는 이벤트
-export type ClientEvent = 'client:join-room' | 'client:answer'
+export type ClientEvent = 'client:join-room' | 'client:submit-answer'
 
 export interface IInterviewSocket {
   connect(url: string, sessionId: string): void


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-98](https://konkuk-graduation-project.atlassian.net/browse/AIEW-98)
- **Branch**: feature/AIEW-98

---

### 작업 내용 📌

- interview 기능 추가
- sttStore 생성
  - stt와 관련된 로직을 구현
  - interviewStore에서 stt session connect 시도

---

### 변경사항 🖥️

<img width="1235" height="844" alt="image" src="https://github.com/user-attachments/assets/30b76a91-c6a2-428e-9e12-4564612b3084" />

---

### 테스트 방법 🧑🏻‍🔬

(리뷰어가 이 변경사항을 어떻게 테스트하고 검증할 수 있는지 설명합니다.)

- `pnpm dev` 실행 후 테스트
- [interview](http://localhost:4000/interview) 페이지에 접속
- ready 상태의 interview 중 하나를 선택해 `start interview` 클릭
- `답변 시작` 버튼 활성화시 버튼 클릭
- 질문에 대해 답할 경우 오른쪽 Pannel에 내가 한 말이 text로 나타나는지 확인
- 모든 text가 나타났을 때 `답변 완료` 클릭
- 10초 정도 대기
- 음성이 나타나면서 새로운 질문이 나타나는지 확인

---

### 참고 사항 📂

- 구조 등 아직 많이 부족합니다. 큰 흐름만 파악하면 좋을 것 같습니다
- interview를 생성한 직후 시작하지 않으면 tts가 실행 안 됩니다.
  - 첫 질문은 question-ready의 steps[0]을 이용합니다
  - 문제는 question-audio-ready event가 발생하지 않습니다
  - 프론트 입장에서는 첫번째 질문도 next-question과 동일한 형식으로 값을 받고 싶습니다
- 답변을 5번 이상할 경우 서버단에 오류가 발생합니다
  - 원인을 파악하려고 했으나 몸이 지쳐 다음 스프린트로 넘길까 합니다