### PR TITLE
[AIEW-99] 면접 질문 제공 로직 통합

### DIFF
--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -1,4 +1,4 @@
-import { User } from '@prisma/client'
+import { InterviewStep, User } from '@prisma/client'
 import fp from 'fastify-plugin'
 import { Server, Socket } from 'socket.io'
 
@@ -70,7 +70,9 @@ export default fp(
         try {
           const session = await fastify.prisma.interviewSession.findFirst({
             where: { id: sessionId, userId: socket.user.id },
+            select: { id: true, status: true },
           })
+
           if (session) {
             await socket.join(sessionId)
             fastify.log.info(
@@ -79,15 +81,22 @@ export default fp(
             // 방 참여 성공을 클라이언트에게 알림 (For testing)
             socket.emit('server:room-joined', { sessionId })
 
-            // 재접속 시 이미 질문이 준비되었는지 확인 후 전송
-            const steps = await fastify.prisma.interviewStep.findMany({
-              where: { interviewSessionId: sessionId },
-              orderBy: { createdAt: 'asc' },
-            })
-
-            // 질문(steps)이 이미 존재한다면, 즉시 해당 클라이언트에게 전송합니다.
-            if (steps.length > 0) {
-              socket.emit('server:questions-ready', { steps })
+            // Race Condition 해결: 만약 방에 접속했는데 질문 생성이 이미 완료된 상태라면,
+            // 이벤트를 놓쳤을 수 있으니 해당 클라이언트에게만 다시 보내줍니다.
+            if (
+              session.status === 'READY' ||
+              session.status === 'IN_PROGRESS' ||
+              session.status === 'COMPLETED' // TODO: 완료 상태로 들어올 때 처리
+            ) {
+              fastify.log.info(
+                `[${sessionId}] Questions are already ready. Notifying re-joined client ${socket.id}.`,
+              )
+              socket.emit('server:questions-ready', { sessionId })
+            } else if (session.status === 'FAILED') {
+              socket.emit('server:error', {
+                code: 'INTERVIEW_SETUP_FAILED',
+                message: 'Failed to set up the interview. Please try again.',
+              })
             }
           } else {
             fastify.log.warn(
@@ -103,6 +112,66 @@ export default fp(
             error,
           )
           socket.emit('server:error', { message: 'Error joining room.' })
+        }
+      })
+
+      socket.on('client:ready', async ({ sessionId }) => {
+        try {
+          const session = await fastify.prisma.interviewSession.findFirst({
+            where: { id: sessionId, userId: socket.user.id },
+          })
+          if (!session) {
+            return socket.emit('server:error', {
+              message: 'Unauthorized or session not found.',
+            })
+          }
+
+          let currentQuestion: InterviewStep | null = null
+
+          if (session.status === 'IN_PROGRESS') {
+            // 진행 중인 경우, 현재 인덱스의 메인 질문을 찾음
+            const mainQuestions = await fastify.prisma.interviewStep.findMany({
+              where: { interviewSessionId: sessionId, parentStepId: null },
+              orderBy: { aiQuestionId: 'asc' },
+            })
+            currentQuestion = mainQuestions[session.currentQuestionIndex]
+          } else if (session.status === 'READY') {
+            // 준비 상태인 경우, 첫 번째 질문을 찾음
+            currentQuestion = await fastify.prisma.interviewStep.findFirst({
+              where: { interviewSessionId: sessionId },
+              orderBy: { createdAt: 'asc' },
+            })
+          }
+
+          if (currentQuestion) {
+            // 헬퍼 메소드는 interviewService에서 가져와 사용
+            const questionPayloadForAi =
+              fastify.interviewService.formatStepToAiQuestion(currentQuestion)
+
+            await fastify.aiClientService.logShownQuestion(
+              { question: questionPayloadForAi },
+              sessionId,
+            )
+
+            const audioBase64 = await fastify.ttsService.generate(
+              currentQuestion.question,
+            )
+
+            socket.emit('server:next-question', {
+              step: currentQuestion,
+              isFollowUp: !!currentQuestion.parentStepId, // 꼬리질문 여부 확인
+              audioBase64,
+            })
+          }
+          // 다른 상태(COMPLETED, FAILED 등)에서는 아무것도 보내지 않음
+        } catch (error) {
+          fastify.log.error(
+            `Error handling client:ready for session ${sessionId}:`,
+            error,
+          )
+          socket.emit('server:error', {
+            message: 'Failed to start or resume the interview.',
+          })
         }
       })
 

--- a/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/InterviewerPannel.tsx
+++ b/apps/web-client/src/app/(main)/interview/(socket)/[sessionId]/_comonents/InterviewerPannel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useInterviewStore } from '@/app/lib/socket/interviewStore'
 import { useSttStore } from '@/app/lib/socket/sttStore'
@@ -11,13 +11,47 @@ export default function InterviewerPannel({
   sessionId: string
 }) {
   const currentQuestion = useInterviewStore((state) => state.current)
+  const [isSpeaking, setIsSpeaking] = useState(true)
+
+  const audioRef = useRef<HTMLAudioElement | null>(null)
 
   useEffect(() => {
+    if (!sessionId || !currentQuestion) return
+
     useSttStore.getState().connect(sessionId)
+
+    if (currentQuestion?.audioBase64) {
+      const audio = new Audio(
+        `data:audio/mp3;base64,${currentQuestion.audioBase64}`,
+      )
+      audioRef.current = audio
+      //화면이 실행될 때 자동 재생 시도
+      //브라우저 정책에 따라 실패 가능
+      //실패시 버튼으로 클릭할 수 있도록 함
+      audio
+        .play()
+        .then(() => setIsSpeaking(true))
+        .catch((err) => {
+          setIsSpeaking(false)
+          console.log('audio autoplay error', err)
+        })
+    }
 
     return () => {
       useSttStore.getState().disconnect()
+      if (audioRef.current) {
+        audioRef.current.pause()
+        audioRef.current = null
+      }
     }
   }, [currentQuestion])
-  return <div>{currentQuestion?.text}</div>
+
+  return (
+    <div>
+      {!isSpeaking && (
+        <button onClick={() => audioRef.current?.play()}>stt start</button>
+      )}
+      <p>{currentQuestion?.text}</p>
+    </div>
+  )
 }

--- a/apps/web-client/src/app/lib/socket/types.ts
+++ b/apps/web-client/src/app/lib/socket/types.ts
@@ -10,7 +10,10 @@ export type ServerEvent =
   | 'server:error'
 
 // 클라이언트에서 보내는 이벤트
-export type ClientEvent = 'client:join-room' | 'client:submit-answer'
+export type ClientEvent =
+  | 'client:join-room'
+  | 'client:submit-answer'
+  | 'client:ready'
 
 export interface IInterviewSocket {
   connect(url: string, sessionId: string): void


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-99](https://konkuk-graduation-project.atlassian.net/browse/AIEW-99)
- **Branch**: refactor/AIEW-99

---

### 작업 내용 📌

- 면접 흐름에서 사용되던 서버측 웹소켓 이벤트를 통합 및 정리하는 과정
  - `server:questions-ready`는 이제 `stepId`만 제공합니다
  - `server:question-audio-ready`는 이제 사용되지 않습니다
  - `server:next-question`을 통해서만 질문이 제공됩니다
  - `client:ready`이벤트를 ACK 처럼 사용할 예정입니다

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행
- [인터뷰 페이지](http://localhost:4000/interview)에서 인터뷰 세션 실행
- 질문 수신과 답변 처리가 정상적으로 진행되는지 확인

---

### 참고 사항 📂

- 마지막 커밋에 Next.js 코드 변경점을 모아두었습니다
- 현재 브랜치에서 작업하셔도 되고, 새로운 브랜치에서 따로 작업하셔도 됩니다 
- 만약 현재 브랜치에서 작업하신다면 마지막 커밋 메시지를 `git commit --amend`로 변경하시는걸 권장드립니다


[AIEW-99]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ