### PR TITLE
[AIEW-72] 세션 평가 API 연결

### DIFF
--- a/apps/core-api/src/plugins/services/ai-client.ts
+++ b/apps/core-api/src/plugins/services/ai-client.ts
@@ -4,10 +4,11 @@ import fp from 'fastify-plugin'
 import {
   AiQuestionRequest,
   AnswerEvaluationRequest,
-  EvaluationResult,
+  AnswerEvaluationResult,
   FollowUp,
   FollowupRequest,
   QuestionGenerateResponse,
+  SessionEvaluationResult,
   ShownQuestion,
   UserAnswer,
 } from '@/types/ai.types'
@@ -89,10 +90,27 @@ export class AiClientService {
   async evaluateAnswer(
     data: AnswerEvaluationRequest,
     sessionId: string,
-  ): Promise<EvaluationResult> {
-    const response = await this.client.post<EvaluationResult>(
+  ): Promise<AnswerEvaluationResult> {
+    const response = await this.client.post<AnswerEvaluationResult>(
       '/api/v1/evaluation/answer-evaluating',
       data,
+      {
+        headers: {
+          'X-Session-Id': sessionId,
+        },
+      },
+    )
+    return response.data
+  }
+
+  /**
+   * 전체 면접 세션에 대한 평가를 AI 서버에 요청합니다.
+   * @param sessionId - 현재 면접 세션 ID
+   */
+  async evaluateSession(sessionId: string): Promise<SessionEvaluationResult> {
+    const response = await this.client.post<SessionEvaluationResult>(
+      '/api/v1/evaluation/session-evaluating',
+      null, // 요청 본문이 없음
       {
         headers: {
           'X-Session-Id': sessionId,

--- a/apps/core-api/src/plugins/services/interview.ts
+++ b/apps/core-api/src/plugins/services/interview.ts
@@ -752,7 +752,9 @@ export class InterviewService {
     log.info(`[${sessionId}] Next question logged to AI memory.`)
 
     // 꼬리 질문 음성 생성
+    console.time('tts')
     const audioBase64 = await ttsService.generate(newFollowupStep.question)
+    console.timeEnd('tts')
 
     io.to(sessionId).emit('server:next-question', {
       step: newFollowupStep,
@@ -822,7 +824,9 @@ export class InterviewService {
       log.info(`[${sessionId}] Next question logged to AI memory.`)
 
       // 다음 메인 질문 음성 생성
+      console.time('tts')
       const audioBase64 = await ttsService.generate(nextStep.question)
+      console.timeEnd('tts')
 
       io.to(sessionId).emit('server:next-question', {
         step: nextStep,

--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -152,10 +152,11 @@ export default fp(
               { question: questionPayloadForAi },
               sessionId,
             )
-
+            console.time('tts')
             const audioBase64 = await fastify.ttsService.generate(
               currentQuestion.question,
             )
+            console.timeEnd('tts')
 
             socket.emit('server:next-question', {
               step: currentQuestion,

--- a/apps/core-api/src/types/ai.types.ts
+++ b/apps/core-api/src/types/ai.types.ts
@@ -75,9 +75,9 @@ export interface CriterionScore {
 }
 
 /**
- * AI 서버의 /evaluate-answer 엔드포인트 응답 객체 타입
+ * AI 서버의 /answer-evaluating 엔드포인트 응답 객체 타입
  */
-export interface EvaluationResult {
+export interface AnswerEvaluationResult {
   question_id: string
   category: string
   answer_duration_sec: number
@@ -100,7 +100,7 @@ export interface SessionEvaluationResult {
 }
 
 /**
- * AI 서버의 /evaluate-answer 엔드포인트 요청 본문 타입
+ * AI 서버의 /answer-evaluating 엔드포인트 요청 본문 타입
  */
 export interface AnswerEvaluationRequest {
   question_id: string

--- a/apps/core-api/src/types/ai.types.ts
+++ b/apps/core-api/src/types/ai.types.ts
@@ -92,6 +92,14 @@ export interface EvaluationResult {
 }
 
 /**
+ * AI 서버의 /session-evaluating 엔드포인트 응답 객체 타입
+ */
+export interface SessionEvaluationResult {
+  average_score: number
+  session_feedback: string
+}
+
+/**
  * AI 서버의 /evaluate-answer 엔드포인트 요청 본문 타입
  */
 export interface AnswerEvaluationRequest {


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-72](https://konkuk-graduation-project.atlassian.net/browse/AIEW-72)
- **Branch**: feature/AIEW-72

---

### 작업 내용 📌

- `ai-server`의 세션 평가 API 연결
- `POST /api/v1/evaluation/session-evaluating`
- 프론트에 면접 종료를 우선 알리고 백그라운드에서 세션 평가 및 DB 업데이트 진행
- 면접을 진행해보니 간혹 잘못된 `aiQuestionId`가 생기는 경우를 식별 (ex: q2-fu1-fu2)
  - 이를 해결하기 위해 항상 메인 질문 ID를 꼬리 질문 생성 요청에 포함시킴
- tts 실행시간 측정을 위한 로그 추가

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행
- [인터뷰 페이지](http://localhost:4000/interview)에서 세션 실행
- 면접이 끝날 때까지 답변
  - 끝나는 시점을 파악하기 위해서는 개발자 도구 -> Network 에서 웹소켓 이벤트를 통해 `aiQuestionId` 확인
  - [DB 콘솔](https://console.prisma.io/htr9n1yjymu2pawsvxfpmn0q/cme2venx00e7z3q0v7nu0o0pc/cme2venx00e7x3q0vc6m5v3d1/studio#table=InterviewSession&schema=public&view=table)에서 `finalFeedback` 확인

---

### 참고 사항 📂

- #76 부터 선형적으로 쌓인 PR입니다
- merge description을 깔끔하게 유지하기 위해서는 이전 PR merge한 후, rebase 진행하여 squash and merge 하는 것을 권장합니다


[AIEW-72]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ