### PR TITLE
[AIEW-100] 랭체인 메모리 리셋

### DIFF
--- a/apps/core-api/src/plugins/services/ai-client.ts
+++ b/apps/core-api/src/plugins/services/ai-client.ts
@@ -169,6 +169,18 @@ export class AiClientService {
       },
     })
   }
+
+  /**
+   * 특정 세션의 AI 서버 메모리를 초기화합니다.
+   * @param sessionId - 초기화할 면접 세션 ID
+   */
+  async resetMemory(sessionId: string): Promise<void> {
+    await this.client.delete('/api/v1/memory-debug/reset', {
+      headers: {
+        'X-Session-Id': sessionId,
+      },
+    })
+  }
 }
 
 export default fp(


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-100](https://konkuk-graduation-project.atlassian.net/browse/AIEW-100)
- **Branch**: feature/AIEW-100

---

### 작업 내용 📌

- 세션별 컨텍스트 유지를 위해 랭체인에서 사용되는 `ConversationBufferMemory`를 리셋하는 API 호출
  - AI 재처리가 필요한 업데이트
  - 세션 삭제
  - 세션 평가 직후

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm dev` 실행
- [인터뷰 페이지](http://localhost:4000/interview)에서 세션 하나 진행
- IN_PROGRESS 상태일 때 [AI Swagger](http://localhost:8000/docs#/Memory%20Debug/get_memory_dump_api_v1_memory_debug_dump_get)에서 메모리 확인
- 세션 삭제, 업데이트, 종료해보며 메모리 확인

---

### 참고 사항 📂

- 제대로 진행되지 않으면 유저들과 세션들이 누적됨에 따라 많은 리소스를 사용하니 중요한 기능


[AIEW-100]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ