### PR TITLE
[AIEW-110] IN_PROGRESS 세션의 첫 질문 선정

### DIFF
--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -129,17 +129,21 @@ export default fp(
           let currentQuestion: InterviewStep | null = null
 
           if (session.status === 'IN_PROGRESS') {
-            // 진행 중인 경우, 현재 인덱스의 메인 질문을 찾음
-            const mainQuestions = await fastify.prisma.interviewStep.findMany({
-              where: { interviewSessionId: sessionId, parentStepId: null },
-              orderBy: { aiQuestionId: 'asc' },
+            // 진행 중인 경우, 답변이 없는 질문을 찾음 (메인/꼬리 모두 포함)
+            currentQuestion = await fastify.prisma.interviewStep.findFirst({
+              where: {
+                interviewSessionId: sessionId,
+                answer: null,
+              },
+              orderBy: {
+                aiQuestionId: 'asc',
+              },
             })
-            currentQuestion = mainQuestions[session.currentQuestionIndex]
           } else if (session.status === 'READY') {
             // 준비 상태인 경우, 첫 번째 질문을 찾음
             currentQuestion = await fastify.prisma.interviewStep.findFirst({
               where: { interviewSessionId: sessionId },
-              orderBy: { createdAt: 'asc' },
+              orderBy: { aiQuestionId: 'asc' },
             })
           }
 


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-110](https://konkuk-graduation-project.atlassian.net/browse/AIEW-110)
- **Branch**: bugfix/AIEW-110

---

### 작업 내용 📌

- `IN_PROGRESS` InterviewSession 실행시 첫 질문으로 직전에 답변한 메인 질문이 전송되는 문제 발생
- 이를 해결하기 위해 해당 세션의 모든 질문 중 답변이 없는 질문을 `aiQuestionId`로 정렬하여 가장 앞의 질문을 전송

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm build && pnpm dev` 실행
- 진행중이던 세션에 접속하여 마지막에 답변했던 질문의 다음 질문이 정상적으로 도착하는지 확인

---

### 참고 사항 📂

- 개인 사정과 차분시 VM 설정 이슈로 이제야 작업 시작합니데이...


[AIEW-110]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ