### PR TITLE
[AIEW-104] 면접 세션 진행 시간 & 답변 완료된 질문 리스트

### DIFF
--- a/apps/core-api/prisma/migrations/20250928074748_add_timestamp_fields/migration.sql
+++ b/apps/core-api/prisma/migrations/20250928074748_add_timestamp_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "InterviewStep" ADD COLUMN     "answerEndedAt" TIMESTAMP(3),
+ADD COLUMN     "answerStartedAt" TIMESTAMP(3);

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -86,6 +86,8 @@ model InterviewStep {
 
   // ++ 추가: 답변 및 평가에 대한 상세 정보
   answerDurationSec      Int?      // 실제 사용자 답변 시간 (초)
+  answerStartedAt        DateTime? // 답변 시작 시간
+  answerEndedAt          DateTime? // 답변 종료 시간
   strengths              String[]  // AI가 평가한 강점 목록
   improvements           String[]  // AI가 평가한 개선점 목록
   redFlags               String[]  // AI가 발견한 위험 신호 목록

--- a/apps/core-api/src/plugins/socket.ts
+++ b/apps/core-api/src/plugins/socket.ts
@@ -97,9 +97,16 @@ export default fp(
                 {
                   where: {
                     interviewSessionId: sessionId,
+                    parentStepId: null, // 메인 질문만,
                     answer: { not: null },
                   },
                   orderBy: { aiQuestionId: 'asc' },
+                  include: {
+                    tailSteps: {
+                      where: { answer: { not: null } },
+                      orderBy: { aiQuestionId: 'asc' },
+                    },
+                  },
                 },
               )
 

--- a/apps/core-api/test/services/interview.service.test.ts
+++ b/apps/core-api/test/services/interview.service.test.ts
@@ -202,6 +202,8 @@ describe('InterviewService Unit Tests', () => {
       expect(app.io.to(session.id).emit).toHaveBeenCalledWith(
         'server:questions-ready',
         {
+          answeredSteps: [],
+          elapsedSec: 0,
           sessionId: session.id,
         },
       )


### PR DESCRIPTION
### JIRA Task 🔖

- **Ticket**: [AIEW-104](https://konkuk-graduation-project.atlassian.net/browse/AIEW-104)
- **Branch**: feature/AIEW-104

---

### 작업 내용 📌

- #80 의 요구사항 반영
  - `client:submit-elapsedSec` 핸들러 추가
  - `server:questions-ready` payload 추가
    - 면접 세션 진행시간인 `elapsedSec`
    - 답변 완료된 질문들을 순서대로 담은 `answeredSteps`

---

### 테스트 방법 🧑🏻‍🔬

- `pnpm build && pnpm dev` 실행
- [새로운 면접 세션 생성](http://localhost:4000/interview/create)
- 어느 정도 진행 후 개발자 도구 실행 -> Network 탭
- 인터뷰 중간 종료 후 재실행
- 소켓 이벤트를 통해 답변 완료된 질문들과 전체 면접 시간이 정상적으로 전송되는지 확인

---

### 참고 사항 📂

- #81 과 동일한 파일을 수정하였기에 conflict 발생 가능성 존재


[AIEW-104]: https://konkuk-graduation-project.atlassian.net/browse/AIEW-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ